### PR TITLE
Style fix

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -5,10 +5,10 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin')
 config.vue.loaders = {
   js: 'babel!eslint',
   // http://vuejs.github.io/vue-loader/configurations/extract-css.html
-  css: ExtractTextPlugin.extract("css"),
-  less: ExtractTextPlugin.extract("css!less"),
-  sass: ExtractTextPlugin.extract("css!sass"),
-  stylus: ExtractTextPlugin.extract("css!stylus")
+  css: ExtractTextPlugin.extract('css'),
+  less: ExtractTextPlugin.extract('css!less'),
+  sass: ExtractTextPlugin.extract('css!sass'),
+  stylus: ExtractTextPlugin.extract('css!stylus')
 }
 
 // http://vuejs.github.io/vue-loader/workflow/production.html


### PR DESCRIPTION
Make `webpack` config file compatible with `ESlint` configuration.

Using Atom editor I'd get `eslint` error for using double quotes also for config file.