### PR TITLE
Improved css loader support

### DIFF
--- a/template/build/css-loaders.js
+++ b/template/build/css-loaders.js
@@ -1,0 +1,52 @@
+var ExtractTextPlugin = require('extract-text-webpack-plugin')
+
+module.exports = function (options) {
+  // generate loader string to be used with extract text plugin
+  function generateLoaders (loaders) {
+    var sourceLoader = loaders.map(function (loader) {
+      var extraParamChar
+      if (/\?/.test(loader)) {
+        loader = loader.replace(/\?/, '-loader?')
+        extraParamChar = '&'
+      } else {
+        loader = loader + '-loader'
+        extraParamChar = '?'
+      }
+      return loader + (options.sourceMap ? extraParamChar + 'sourceMap' : '')
+    }).join('!')
+
+    if (options.extract) {
+      return ExtractTextPlugin.extract('vue-style-loader', sourceLoader)
+    } else {
+      return ['vue-style-loader', sourceLoader].join('!')
+    }
+  }
+
+  // http://vuejs.github.io/vue-loader/configurations/extract-css.html
+  return [
+    {
+      key: 'css',
+      value: generateLoaders(['css'])
+    },
+    {
+      key: 'less',
+      value: generateLoaders(['css', 'less'])
+    },
+    {
+      key: 'sass',
+      value: generateLoaders(['css', 'sass?indentedSyntax'])
+    },
+    {
+      key: 'scss',
+      value: generateLoaders(['css', 'sass'])
+    },
+    {
+      key: 'stylus',
+      value: generateLoaders(['css', 'stylus'])
+    },
+    {
+      key: 'styl',
+      value: generateLoaders(['css', 'stylus'])
+    }
+  ]
+}

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -1,9 +1,19 @@
 var webpack = require('webpack')
 var config = require('./webpack.base.conf')
+var cssLoaders = require('./css-loaders')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 
 // eval-source-map is faster for development
 config.devtool = 'eval-source-map'
+
+config.vue = config.vue || {}
+config.vue.loaders = config.vue.loaders || {}
+cssLoaders({
+  sourceMap: false,
+  extract: false
+}).forEach(function (loader) {
+  config.vue.loaders[loader.key] = loader.value
+})
 
 // add hot-reload related code to entry chunks
 var polyfill = 'eventsource-polyfill'

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -1,5 +1,6 @@
 var webpack = require('webpack')
 var config = require('./webpack.base.conf')
+var cssLoaders = require('./css-loaders')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 
@@ -14,25 +15,13 @@ var SOURCE_MAP = true
 
 config.devtool = SOURCE_MAP ? 'source-map' : false
 
-// generate loader string to be used with extract text plugin
-function generateExtractLoaders (loaders) {
-  return loaders.map(function (loader) {
-    return loader + '-loader' + (SOURCE_MAP ? '?sourceMap' : '')
-  }).join('!')
-}
-
-// http://vuejs.github.io/vue-loader/configurations/extract-css.html
-var cssExtractLoaders = {
-  css: ExtractTextPlugin.extract('vue-style-loader', generateExtractLoaders(['css'])),
-  less: ExtractTextPlugin.extract('vue-style-loader', generateExtractLoaders(['css', 'less'])),
-  sass: ExtractTextPlugin.extract('vue-style-loader', generateExtractLoaders(['css', 'sass'])),
-  stylus: ExtractTextPlugin.extract('vue-style-loader', generateExtractLoaders(['css', 'stylus']))
-}
-
 config.vue = config.vue || {}
 config.vue.loaders = config.vue.loaders || {}
-Object.keys(cssExtractLoaders).forEach(function (key) {
-  config.vue.loaders[key] = cssExtractLoaders[key]
+cssLoaders({
+  sourceMap: SOURCE_MAP,
+  extract: true
+}).forEach(function (loader) {
+  config.vue.loaders[loader.key] = loader.value
 })
 
 config.plugins = (config.plugins || []).concat([


### PR DESCRIPTION
- genericized config for all CSS loaders, so that making them work in both development and production can be done in a single file, while still allowing for differences such as CSS file extraction in production
- explicit support for both `lang="scss"` (unindented syntax) and `lang="sass"` (indented syntax), a la https://github.com/hedefalk/atom-vue/issues/5
- support for both `lang="stylus"` and `lang="styl`"
- all syntaxes have been manually tested in both development and production, so that installing the necessary loader is all that's necessary to get them working