### PR TITLE
Add version to input prompts for package.json template

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -5,6 +5,12 @@
       "required": true,
       "label": "Project name"
     },
+    "version": {
+      "type": "string",
+      "required": true,
+      "label": "Project version",
+      "default": "0.1.0"
+    },
     "description": {
       "type": "string",
       "required": false,

--- a/template/package.json
+++ b/template/package.json
@@ -1,5 +1,6 @@
 {
   "name": "{{ name }}",
+  "version": "{{ version }}",
   "description": "{{ description }}",
   "author": "{{ author }}",
   {{#private}}


### PR DESCRIPTION
Version number in the package.json file is required per the NPM spec: https://docs.npmjs.com/files/package.json

I only noticed this because I use cmder for cli in windows and it has some sort of built in node parser that complains about it after every command until I add the version number.

I tested and seems to work fine.