### PR TITLE
Update karma.config.js to work with CSS preprocessors

### DIFF
--- a/template/test/unit/karma.conf.js
+++ b/template/test/unit/karma.conf.js
@@ -7,6 +7,10 @@ var path = require('path')
 var merge = require('webpack-merge')
 var baseConfig = require('../../build/webpack.base.conf')
 var projectRoot = path.resolve(__dirname, '../../')
+var cssLoaders = require('../../build/css-loaders')({
+  sourceMap: false,
+  extract: false
+})
 
 var webpackConfig = merge(baseConfig, {
   // use inline sourcemap for karma-sourcemap-loader
@@ -17,6 +21,9 @@ var webpackConfig = merge(baseConfig, {
     }
   }
 })
+
+// merge css loaders with vue loaders
+webpackConfig.vue.loaders = merge(webpackConfig.vue.loaders, cssLoaders)
 
 // no need for app entry during tests
 delete webpackConfig.entry


### PR DESCRIPTION
This is a fix to a problem that I ran into when I tried to run unit tests with `<style lang='scss'>` in the `Hello.vue` component.