### PR TITLE
exclude `build` directory when eslint check

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -36,7 +36,7 @@ module.exports = {
         test: /\.js$/,
         loader: 'eslint',
         include: projectRoot,
-        exclude: /node_modules/
+        exclude: /(?:node_modules|\/build\/)/
       }
     ],
     loaders: [


### PR DESCRIPTION
The `build` directory should not be included in the eslint check. Though the current config will not cause any error, but when using eslint-plugin-import will throw error: 

`Unable to resolve path to module 'webpack-hot-middleware/client?noInfo=true&reload=true'`