### PR TITLE
Add hash to the url filename

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -63,7 +63,7 @@ module.exports = {
         loader: 'url',
         query: {
           limit: 10000,
-          name: path.join(config.build.assetsSubDirectory, '[name].[ext]?[hash:7]')
+          name: path.join(config.build.assetsSubDirectory, '[name].[hash:7].[ext]')
         }
       }
     ]


### PR DESCRIPTION
If we have 2 different images with the same name, the webpack serves the one of them.