### PR TITLE
Fix linting issues in the `build` folder

### DIFF
--- a/template/build/build.js
+++ b/template/build/build.js
@@ -1,3 +1,5 @@
+/* global env, rm, mkdir, cp */
+
 // https://github.com/shelljs/shelljs
 require('shelljs/global')
 env.NODE_ENV = 'production'

--- a/template/build/build.js
+++ b/template/build/build.js
@@ -1,4 +1,4 @@
-/* global env, rm, mkdir, cp */
+/* eslint-env shelljs */
 
 // https://github.com/shelljs/shelljs
 require('shelljs/global')

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -1,4 +1,3 @@
-var path = require('path')
 var config = require('../config')
 var webpack = require('webpack')
 var merge = require('webpack-merge')


### PR DESCRIPTION
`npm run lint` runs smoothly, however, `vscode` or `atom` or `subl` or `whatever` will still be reporting linting issues in the build folder