### PR TITLE
fix static path for windows environment

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -1,4 +1,5 @@
 var path = require('path')
+var url = require('url')
 var express = require('express')
 var webpack = require('webpack')
 var config = require('../config')
@@ -53,7 +54,7 @@ app.use(devMiddleware)
 app.use(hotMiddleware)
 
 // serve pure static assets
-var staticPath = path.join(config.build.assetsPublicPath, config.build.assetsSubDirectory)
+var staticPath = url.resolve(config.build.assetsPublicPath, config.build.assetsSubDirectory)
 app.use(staticPath, express.static('./static'))
 
 module.exports = app.listen(port, function (err) {


### PR DESCRIPTION
I made this PR with the help of @myst729.

Using back slash (\\) as file separator is how path.join works in Windows environment, which makes loading of static files failed on my windows machine.
![img1](https://cloud.githubusercontent.com/assets/519733/14449934/97aa2230-00ab-11e6-9c1a-d7a0ec39f6b0.png)
In Mac or Linux it should be slash (/), which works.
![img2](https://cloud.githubusercontent.com/assets/519733/14449926/8135d38c-00ab-11e6-8576-3d1ed49ec166.png)
We think url.resolve is a better approach here.
(The pictures are from @myst729)