### PR TITLE
Fix linting issues in the `build` folder

### DIFF
--- a/template/build/build.js
+++ b/template/build/build.js
@@ -1,3 +1,5 @@
+/* eslint-env shelljs */
+
 // https://github.com/shelljs/shelljs
 require('shelljs/global')
 env.NODE_ENV = 'production'


### PR DESCRIPTION
`env`, `rm`, `mkdir` and `cp` are defined globally. This adds `eslint-env shelljs` directive to let linter know about them.