### PR TITLE
add built-in config for standalone compile-to-css files

### DIFF
--- a/template/build/css-loaders-vue.js
+++ b/template/build/css-loaders-vue.js
@@ -1,0 +1,36 @@
+var ExtractTextPlugin = require('extract-text-webpack-plugin')
+
+module.exports = function (options) {
+  options = options || {}
+  // generate loader string to be used with extract text plugin
+  function generateLoaders (loaders) {
+    var sourceLoader = loaders.map(function (loader) {
+      var extraParamChar
+      if (/\?/.test(loader)) {
+        loader = loader.replace(/\?/, '-loader?')
+        extraParamChar = '&'
+      } else {
+        loader = loader + '-loader'
+        extraParamChar = '?'
+      }
+      return loader + (options.sourceMap ? extraParamChar + 'sourceMap' : '')
+    }).join('!')
+
+    if (options.extract) {
+      return ExtractTextPlugin.extract('vue-style-loader', sourceLoader)
+    } else {
+      return ['vue-style-loader', sourceLoader].join('!')
+    }
+  }
+
+  // http://vuejs.github.io/vue-loader/configurations/extract-css.html
+  return {
+    css: generateLoaders(['css']),
+    postcss: generateLoaders(['css']),
+    less: generateLoaders(['css', 'less']),
+    sass: generateLoaders(['css', 'sass?indentedSyntax']),
+    scss: generateLoaders(['css', 'sass']),
+    stylus: generateLoaders(['css', 'stylus']),
+    styl: generateLoaders(['css', 'stylus'])
+  }
+}

--- a/template/build/css-loaders.js
+++ b/template/build/css-loaders.js
@@ -1,36 +1,28 @@
-var ExtractTextPlugin = require('extract-text-webpack-plugin')
-
 module.exports = function (options) {
-  options = options || {}
-  // generate loader string to be used with extract text plugin
   function generateLoaders (loaders) {
-    var sourceLoader = loaders.map(function (loader) {
-      var extraParamChar
-      if (/\?/.test(loader)) {
-        loader = loader.replace(/\?/, '-loader?')
-        extraParamChar = '&'
-      } else {
-        loader = loader + '-loader'
-        extraParamChar = '?'
-      }
-      return loader + (options.sourceMap ? extraParamChar + 'sourceMap' : '')
-    }).join('!')
+    return ['vue-style'].concat(loaders.join('!')).join('!')
+  }
 
-    if (options.extract) {
-      return ExtractTextPlugin.extract('vue-style-loader', sourceLoader)
-    } else {
-      return ['vue-style-loader', sourceLoader].join('!')
+  return [
+    {
+      test: /\.css$/,
+      loader: generateLoaders(['css'])
+    },
+    {
+      test: /\.less$/,
+      loader: generateLoaders(['css', 'less'])
+    },
+    {
+      test: /\.sass$/,
+      loader: generateLoaders(['css', 'sass?indentedSyntax'])
+    },
+    {
+      test: /\.scss$/,
+      loader: generateLoaders(['css', 'sass'])
+    },
+    {
+      test: /\.styl(us)?$/,
+      loader: generateLoaders(['css', 'stylus'])
     }
-  }
-
-  // http://vuejs.github.io/vue-loader/configurations/extract-css.html
-  return {
-    css: generateLoaders(['css']),
-    postcss: generateLoaders(['css']),
-    less: generateLoaders(['css', 'less']),
-    sass: generateLoaders(['css', 'sass?indentedSyntax']),
-    scss: generateLoaders(['css', 'sass']),
-    stylus: generateLoaders(['css', 'stylus']),
-    styl: generateLoaders(['css', 'stylus'])
-  }
+  ]
 }

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -1,6 +1,7 @@
 var path = require('path')
 var config = require('../config')
 var cssLoaders = require('./css-loaders')
+var cssLoadersVue = require('./css-loaders-vue')
 var projectRoot = path.resolve(__dirname, '../')
 
 module.exports = {
@@ -66,10 +67,10 @@ module.exports = {
           name: path.join(config.build.assetsSubDirectory, '[name].[hash:7].[ext]')
         }
       }
-    ]
+    ].concat(cssLoaders())
   },
   vue: {
-    loaders: cssLoaders()
+    loaders: cssLoadersVue()
   },
   eslint: {
     formatter: require('eslint-friendly-formatter')

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -3,7 +3,7 @@ var config = require('../config')
 var webpack = require('webpack')
 var merge = require('webpack-merge')
 var baseWebpackConfig = require('./webpack.base.conf')
-var cssLoaders = require('./css-loaders')
+var cssLoadersVue = require('./css-loaders-vue')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 
@@ -15,7 +15,7 @@ module.exports = merge(baseWebpackConfig, {
     chunkFilename: path.join(config.build.assetsSubDirectory, '[id].[chunkhash].js')
   },
   vue: {
-    loaders: cssLoaders({
+    loaders: cssLoadersVue({
       sourceMap: config.build.productionSourceMap,
       extract: true
     })


### PR DESCRIPTION
Allows users to just start coding styles in standalone files with the appropriate extension once they install the appropriate loaders and their peer dependencies, similar to how style elements currently work in `.vue` components.