### PR TITLE
Allow external css to be included

### DIFF
--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -40,3 +40,17 @@ exports.cssLoaders = function (options) {
     styl: generateLoaders(['css', 'stylus'])
   }
 }
+
+// Generate loaders for standalone style files (outside of .vue)
+exports.styleLoaders = function (options) {
+  var output = []
+  var loaders = exports.cssLoaders(options)
+  for (var extension in loaders) {
+    var loader = loaders[extension]
+    output.push({
+      test: new RegExp('\\.' + extension + '$'),
+      loader: loader
+    })
+  }
+  return output
+}

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -1,5 +1,6 @@
 var webpack = require('webpack')
 var merge = require('webpack-merge')
+var utils = require('./utils')
 var baseWebpackConfig = require('./webpack.base.conf')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 
@@ -9,6 +10,9 @@ Object.keys(baseWebpackConfig.entry).forEach(function (name) {
 })
 
 module.exports = merge(baseWebpackConfig, {
+  module: {
+    loaders: utils.styleLoaders()
+  },
   // eval-source-map is faster for development
   devtool: '#eval-source-map',
   plugins: [

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -1,4 +1,3 @@
-var path = require('path')
 var config = require('../config')
 var utils = require('./utils')
 var webpack = require('webpack')

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -8,6 +8,9 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 
 module.exports = merge(baseWebpackConfig, {
+  module: {
+    loaders: utils.styleLoaders({ sourceMap: config.build.productionSourceMap, extract: true })
+  },
   devtool: config.build.productionSourceMap ? '#source-map' : false,
   output: {
     path: config.build.assetsRoot,


### PR DESCRIPTION
Basically this is the same idea as https://github.com/vuejs-templates/webpack/pull/81 (being able to include CSS outside of .vue files keeping the hot-reload and extract)
But I wanted to rewrite as few lines as possible to do so, and use the work done within `cssLoaders()`