### PR TITLE
Extract assets to different directory

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -61,11 +61,19 @@ module.exports = {
         loader: 'vue-html'
       },
       {
-        test: /\.(png|jpe?g|gif|svg|woff2?|eot|ttf|otf)(\?.*)?$/,
+        test: /\.(png|jpe?g|gif|svg)(\?.*)?$/,
         loader: 'url',
         query: {
           limit: 10000,
-          name: utils.assetsPath('[name].[hash:7].[ext]')
+          name: utils.assetsPath('img/[name].[hash:7].[ext]')
+        }
+      },
+      {
+        test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
+        loader: 'url',
+        query: {
+          limit: 10000,
+          name: utils.assetsPath('fonts/[name].[hash:7].[ext]')
         }
       }
     ]

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -13,8 +13,8 @@ module.exports = merge(baseWebpackConfig, {
   devtool: config.build.productionSourceMap ? '#source-map' : false,
   output: {
     path: config.build.assetsRoot,
-    filename: utils.assetsPath('[name].[chunkhash].js'),
-    chunkFilename: utils.assetsPath('[id].[chunkhash].js')
+    filename: utils.assetsPath('js/[name].[chunkhash].js'),
+    chunkFilename: utils.assetsPath('js/[id].[chunkhash].js')
   },
   vue: {
     loaders: utils.cssLoaders({
@@ -36,7 +36,7 @@ module.exports = merge(baseWebpackConfig, {
     }),
     new webpack.optimize.OccurenceOrderPlugin(),
     // extract css into its own file
-    new ExtractTextPlugin(utils.assetsPath('[name].[contenthash].css')),
+    new ExtractTextPlugin(utils.assetsPath('css/[name].[contenthash].css')),
     // generate dist index.html with correct asset hash for caching.
     // you can customize output by editing /index.html
     // see https://github.com/ampedandwired/html-webpack-plugin


### PR DESCRIPTION
Imagine that you have these `static` files:
```
├── static/
│   ├── css
│   │   ├── style1.css
│   │   ├── style2.css
│   │   ├── style3.css
│   ├── img
│   │   ├── image1.png
│   │   ├── image2.png
│   │   ├── image3.png
│   ├── js
│   │   ├── script1.js
│   │   ├── script2.js
│   │   ├── script3.js
```

After the build, we get these:
```
├── dist/
│   ├── static/
│   │   ├── css
│   │   │   ├── style1.css
│   │   │   ├── style2.css
│   │   │   ├── style3.css
│   │   ├── img
│   │   │   ├── image1.png
│   │   │   ├── image2.png
│   │   │   ├── image3.png
│   │   ├── js
│   │   │   ├── script1.js
│   │   │   ├── script2.js
│   │   │   ├── script3.js
│   │   ├── app.css
│   │   ├── app.js
│   │   ├── logo.png
│   ├── index.html
```

If we extract the assets to different directories, we get these:
```
├── dist/
│   ├── static/
│   │   ├── css
│   │   │   ├── app.css
│   │   │   ├── style1.css
│   │   │   ├── style2.css
│   │   │   ├── style3.css
│   │   ├── img
│   │   │   ├── image1.png
│   │   │   ├── image2.png
│   │   │   ├── image3.png
│   │   │   ├── logo.png
│   │   ├── js
│   │   │   ├── app.js
│   │   │   ├── script1.js
│   │   │   ├── script2.js
│   │   │   ├── script3.js
│   ├── index.html
```