### PR TITLE
Remove dependency on bind

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -39,7 +39,6 @@
     "express": "^4.13.3",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.4",
-    "function-bind": "^1.0.2",
     "html-webpack-plugin": "^2.8.1",
     "http-proxy-middleware": "^0.12.0",
     "inject-loader": "^2.0.1",

--- a/template/test/unit/index.js
+++ b/template/test/unit/index.js
@@ -1,7 +1,3 @@
-// Polyfill fn.bind() for PhantomJS
-/* eslint-disable no-extend-native */
-Function.prototype.bind = require('function-bind')
-
 // require all test files (files that ends with .spec.js)
 var testsContext = require.context('./specs', true, /\.spec$/)
 testsContext.keys().forEach(testsContext)


### PR DESCRIPTION
Bind was required for Phantomjs v1, but Phantomjs v2 supports bind natively

If this is desired, I can go ahead and adjust the rest of the templates. Just let me know. 