### PR TITLE
Support environment variables

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Linter Configuration](linter.md)
 - [Pre-Processors](pre-processors.md)
 - [Handling Static Assets](static.md)
+- [Environment Variables](env.md)
 - [Integrate with Backend Framework](backend.md)
 - [API Proxying During Development](proxy.md)
 - [Unit Testing](unit.md)

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,0 +1,51 @@
+# Environment Variables
+
+Sometimes it is practical to have different config values according to the environment that the application is running in.
+
+As an example:
+
+```js
+// config/prod.env.js
+module.exports = {
+  NODE_ENV: '"production"',
+  DEBUG_MODE: false,
+  API_KEY: '"..."' // this is shared between all environments
+}
+
+// config/dev.env.js
+module.exports = merge(prodEnv, {
+  NODE_ENV: '"development"',
+  DEBUG_MODE: true // this overrides the DEBUG_MODE value of prod.env
+})
+
+// config/test.env.js
+module.exports = merge(devEnv, {
+  NODE_ENV: '"testing"'
+})
+```
+
+> **Note:** string variables need to be wrapped into single and double quotes `'"..."'`
+
+So, the environment variables are:
+- Production
+    - NODE_ENV   = 'production',
+    - DEBUG_MODE = false,
+    - API_KEY    = '...'
+- Development
+    - NODE_ENV   = 'development',
+    - DEBUG_MODE = true,
+    - API_KEY    = '...'
+- Testing
+    - NODE_ENV   = 'testing',
+    - DEBUG_MODE = true,
+    - API_KEY    = '...'
+
+As we can see, `test.env` inherits the `dev.env` and the `dev.env` inherits the `prod.env`.
+
+### Usage
+
+It is simple to use the environment variables to your code. For example:
+
+```js
+Vue.config.debug = process.env.DEBUG_MODE
+```

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -1,3 +1,4 @@
+var config = require('../config')
 var webpack = require('webpack')
 var merge = require('webpack-merge')
 var utils = require('./utils')
@@ -16,6 +17,9 @@ module.exports = merge(baseWebpackConfig, {
   // eval-source-map is faster for development
   devtool: '#eval-source-map',
   plugins: [
+    new webpack.DefinePlugin({
+      'process.env': config.dev.env
+    }),
     // https://github.com/glenjamin/webpack-hot-middleware#installation--usage
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -5,6 +5,9 @@ var merge = require('webpack-merge')
 var baseWebpackConfig = require('./webpack.base.conf')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
+var env = process.env.NODE_ENV === 'testing'
+  ? require('../config/test.env')
+  : config.build.env
 
 module.exports = merge(baseWebpackConfig, {
   module: {
@@ -25,9 +28,7 @@ module.exports = merge(baseWebpackConfig, {
   plugins: [
     // http://vuejs.github.io/vue-loader/workflow/production.html
     new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: '"production"'
-      }
+      'process.env': env
     }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {

--- a/template/config/dev.env.js
+++ b/template/config/dev.env.js
@@ -1,0 +1,6 @@
+var merge = require('webpack-merge')
+var prodEnv = require('./prod.env')
+
+module.exports = merge(prodEnv, {
+  NODE_ENV: '"development"'
+})

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -3,13 +3,15 @@ var path = require('path')
 
 module.exports = {
   build: {
-    index: path.resolve(__dirname, 'dist/index.html'),
-    assetsRoot: path.resolve(__dirname, 'dist'),
+    env: require('./prod.env'),
+    index: path.resolve(__dirname, '../dist/index.html'),
+    assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',
     productionSourceMap: true
   },
   dev: {
+    env: require('./dev.env'),
     port: 8080,
     proxyTable: {}
   }

--- a/template/config/prod.env.js
+++ b/template/config/prod.env.js
@@ -1,0 +1,3 @@
+module.exports = {
+  NODE_ENV: '"production"'
+}

--- a/template/config/test.env.js
+++ b/template/config/test.env.js
@@ -1,0 +1,6 @@
+var merge = require('webpack-merge')
+var devEnv = require('./dev.env')
+
+module.exports = merge(devEnv, {
+  NODE_ENV: '"testing"'
+})

--- a/template/test/unit/karma.conf.js
+++ b/template/test/unit/karma.conf.js
@@ -7,6 +7,7 @@ var path = require('path')
 var merge = require('webpack-merge')
 var baseConfig = require('../../build/webpack.base.conf')
 var utils = require('../../build/utils')
+var webpack = require('webpack')
 var projectRoot = path.resolve(__dirname, '../../')
 
 var webpackConfig = merge(baseConfig, {
@@ -19,7 +20,12 @@ var webpackConfig = merge(baseConfig, {
     loaders: {
       js: 'isparta'
     }
-  }
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': require('../../config/test.env')
+    })
+  ]
 })
 
 // no need for app entry during tests


### PR DESCRIPTION
Sometimes we want to have different values based on the environment.

Example:
```js
// prod.env
DEBUG_MODE: false,
API_URL: 'https://example.com'

// dev.env
DEBUG_MODE: true,
API_URL: 'http://localhost:8080'

// usage
Vue.config.debug = process.env.DEBUG_MODE
Vue.http.options.root = process.env.API_URL
```