### PR TITLE
Split vendor JS into its own bundle

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -1,3 +1,4 @@
+var path = require('path')
 var config = require('../config')
 var utils = require('./utils')
 var webpack = require('webpack')
@@ -52,7 +53,28 @@ module.exports = merge(baseWebpackConfig, {
         removeAttributeQuotes: true
         // more options:
         // https://github.com/kangax/html-minifier#options-quick-reference
+      },
+      // necessary to consistently work with multiple chunks via CommonsChunkPlugin
+      chunksSortMode: 'dependency'
+    }),
+    // split vendor js into its own file
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'vendor',
+      minChunks: function (module, count) {
+        // any required modules inside node_modules are extracted to vendor
+        return (
+          module.resource &&
+          module.resource.indexOf(
+            path.posix.join(__dirname, '../node_modules')
+          ) === 0
+        )
       }
+    }),
+    // extract webpack runtime and module manifest to its own file in order to
+    // prevent vendor hash from being updated whenever app bundle is updated
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'manifest',
+      chunks: ['vendor']
     })
   ]
 })


### PR DESCRIPTION
As an aside, should we set `dist` as the main branch?