### PR TITLE
add vue alias for faster compiling

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -18,13 +18,17 @@ module.exports = {
     alias: {
       'src': path.resolve(__dirname, '../src'),
       'assets': path.resolve(__dirname, '../src/assets'),
-      'components': path.resolve(__dirname, '../src/components')
+      'components': path.resolve(__dirname, '../src/components'),
+      'vue': path.resolve(__dirname, '../node_modules/vue/dist/vue.common.js')
     }
   },
   resolveLoader: {
     fallback: [path.join(__dirname, '../node_modules')]
   },
   module: {
+    noParse: [
+      /vue\.common\.js/
+    ],
     {{#lint}}
     preLoaders: [
       {


### PR DESCRIPTION
By default, `import Vue from 'vue'` will redirect to `node_modules/vue/dist/vue.common.js`, which can cause some filesystem search cost. Considering `vue` is frequently imported in projects, so I specific `alias` and `noParse` for `vue` in webpack configuration.