### PR TITLE
clarify link text to backend page

### DIFF
--- a/docs/static.md
+++ b/docs/static.md
@@ -53,4 +53,4 @@ module.exports = {
 
 Any file placed in `static/` should be referenced using the absolute URL `/static/[filename]`. If you change `assetSubDirectory` to `assets`, then these URLs will need to be changed to `/assets/[filename]`.
 
-We will learn more about the config file in the [next section](backend.md).
+We will learn more about the config file in the section about [backend integration](backend.md).


### PR DESCRIPTION
Since the backend page is not really the next page from the static assets page, as stated before, this fix clarifies the link destination text.