### PR TITLE
only bundle js files in vendor.js

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -65,6 +65,7 @@ module.exports = merge(baseWebpackConfig, {
         // any required modules inside node_modules are extracted to vendor
         return (
           module.resource &&
+          /\.js$/.test(module.resource) &&
           module.resource.indexOf(
             path.join(__dirname, '../node_modules')
           ) === 0


### PR DESCRIPTION
There is an issue when `@import` css files from `node_modules`, see [details](https://github.com/vuejs/vue-loader/issues/249).

The vendor.js should only bundle js files.