### PR TITLE
add beta tag to airbnb linting option

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -30,9 +30,9 @@
           "short": "Standard"
         },
         {
-          "name": "AirBNB (https://github.com/airbnb/javascript)",
+          "name": "Airbnb (BETA) (https://github.com/airbnb/javascript)",
           "value": "airbnb",
-          "short": "AirBNB"
+          "short": "Airbnb (BETA)"
         },
         {
           "name": "none (configure it yourself)",


### PR DESCRIPTION
- Added beta tag to Airbnb option so that people aren't surprised when it's not as much a first-class citizen as feross/standard at this point
- Corrected capitalization from `AirBNB` to `Airbnb`

@yyx990803 Does this look OK to you?