### PR TITLE
Add eslint ignore

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Linter Configuration](linter.md)
 - [Pre-Processors](pre-processors.md)
 - [Handling Static Assets](static.md)
+- [Environment Variables](env.md)
 - [Integrate with Backend Framework](backend.md)
 - [API Proxying During Development](proxy.md)
 - [Unit Testing](unit.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,6 +3,7 @@
 - [Project Structure](structure.md)
 - [Build Commands](commands.md)
 - [Linter Configuration](linter.md)
+- [Pre-Processors](pre-processors.md)
 - [Handling Static Assets](static.md)
 - [Integrate with Backend Framework](backend.md)
 - [API Proxying During Development](proxy.md)

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -1,8 +1,8 @@
 # Integrating with Backend Framework
 
-If you are building a purely-static app (one that is deployed separately from the backend API), then you probably don't even need to edit `config.js`. However, if you want to integrate this template with an existing backend framework, e.g. Rails/Django/Laravel, which comes with their own project structures, you can edit `config.js` to directly generate front-end assets into your backend project.
+If you are building a purely-static app (one that is deployed separately from the backend API), then you probably don't even need to edit `config/index.js`. However, if you want to integrate this template with an existing backend framework, e.g. Rails/Django/Laravel, which comes with their own project structures, you can edit `config/index.js` to directly generate front-end assets into your backend project.
 
-Let's take a look at the default `config.js`:
+Let's take a look at the default `config/index.js`:
 
 ``` js
 var path = require('path')

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,0 +1,51 @@
+# Environment Variables
+
+Sometimes it is practical to have different config values according to the environment that the application is running in.
+
+As an example:
+
+```js
+// config/prod.env.js
+module.exports = {
+  NODE_ENV: '"production"',
+  DEBUG_MODE: false,
+  API_KEY: '"..."' // this is shared between all environments
+}
+
+// config/dev.env.js
+module.exports = merge(prodEnv, {
+  NODE_ENV: '"development"',
+  DEBUG_MODE: true // this overrides the DEBUG_MODE value of prod.env
+})
+
+// config/test.env.js
+module.exports = merge(devEnv, {
+  NODE_ENV: '"testing"'
+})
+```
+
+> **Note:** string variables need to be wrapped into single and double quotes `'"..."'`
+
+So, the environment variables are:
+- Production
+    - NODE_ENV   = 'production',
+    - DEBUG_MODE = false,
+    - API_KEY    = '...'
+- Development
+    - NODE_ENV   = 'development',
+    - DEBUG_MODE = true,
+    - API_KEY    = '...'
+- Testing
+    - NODE_ENV   = 'testing',
+    - DEBUG_MODE = true,
+    - API_KEY    = '...'
+
+As we can see, `test.env` inherits the `dev.env` and the `dev.env` inherits the `prod.env`.
+
+### Usage
+
+It is simple to use the environment variables to your code. For example:
+
+```js
+Vue.config.debug = process.env.DEBUG_MODE
+```

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -10,10 +10,6 @@ If you are not happy with the default linting rules, you have several options:
   "semi": [2, "always"]
   ```
 
-2. Remove the `extends: 'standard'` line in `.eslintrc.js` and use a completely custom eslint config. See [ESLint documentation](http://eslint.org/docs/user-guide/configuring) for more details.
+2. Pick a different ESLint preset when generating the project, for example [eslint-config-airbnb](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb).
 
-3. Use a different ESLint preset, for example [eslint-config-airbnb](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb).
-
-4. Disable linting altogether: comment out the `module.preLoaders` block in `build/webpack.base.conf.js`.
-
-  You will also need to disable linting if you are using a compile-to-JavaScript language, e.g. CoffeeScript.
+3. Pick "none" for ESLint preset when generating the project and define your own rules. See [ESLint documentation](http://eslint.org/docs/rules/) for more details.

--- a/docs/pre-processors.md
+++ b/docs/pre-processors.md
@@ -1,0 +1,51 @@
+# Pre-Processors
+
+This boilerplate has pre-configured CSS extraction for most popular CSS pre-processors including LESS, SASS, Stylus, and PostCSS. To use a pre-processor, all you need to do is installing the appropriate webpack loader for it. For example, to use SASS:
+
+``` bash
+npm install sass-loader node-sass --save-dev
+```
+
+Note you also need to install `node-sass` because `sass-loader` depends on it as a peer dependency.
+
+### Using Pre-Processors inside Components
+
+Once installed, you can use the pre-processors inside your `*.vue` components using the `lang` attribute on `<style>` tags:
+
+``` html
+<style lang="scss">
+/* write SASS! */
+</style>
+```
+
+### A note on SASS syntax
+
+- `lang="scss"` corresponds to the CSS-superset syntax (with curly braces and semicolones).
+- `lang="sass"` corresponds to the indentation-based syntax.
+
+### PostCSS
+
+Styles in `*.vue` files are piped through PostCSS by default, so you don't need to use a specific loader for it. You can simply add PostCSS plugins you want to use in `build/webpack.base.conf.js` under the `vue` block:
+
+``` js
+// build/webpack.base.conf.js
+module.exports = {
+  // ...
+  vue: {
+    postcss: [/* your plugins */]
+  }
+}
+```
+
+See [vue-loader's related documentation](http://vuejs.github.io/vue-loader/features/postcss.html) for more details.
+
+### Standalone CSS Files
+
+To ensure consistent extraction and processing, it is recommended to import global, standalone style files from your root `App.vue` component, for example:
+
+``` html
+<!-- App.vue -->
+<style src="./styles/global.less" lang="less"></style>
+```
+
+Note you should probably only do this for the styles written by yourself for your application. For existing libraries e.g. Bootstrap or Semantic UI, you can place them inside `/static` and reference them directly in `index.html`. This avoids extra build time and also is better for browser caching. (See [Static Asset Handling](static.md))

--- a/docs/static.md
+++ b/docs/static.md
@@ -20,6 +20,20 @@ Since these assets may be inlined/copied/renamed during build, they are essentia
 
 - **Root-relative URLs**, e.g. `/assets/logo.png` are not processed at all.
 
+### Getting Asset Paths in JavaScript
+
+In order for Webpack to return the correct asset paths, you need to use `require('./relative/path/to/file.jpg')`, which will get processed by `file-loader` and returns the resolved URL. For example:
+
+``` js
+computed: {
+  background () {
+    return require('./bgs/' + this.id + '.jpg')
+  }
+}
+```
+
+**Note the above example will include every image under `./bgs/` in the final build.** This is because Webpack cannot guess which of them will be used at runtime, so it includes them all.
+
 ### "Real" Static Assets
 
 In comparison, files in `static/` are not processed by Webpack at all: they are directly copied to their final destination as-is, with the same filename. You must reference these files using absolute paths, which is determined by joining `build.assetsPublicPath` and `build.assetsSubDirectory` in `config.js`.

--- a/docs/static.md
+++ b/docs/static.md
@@ -53,4 +53,4 @@ module.exports = {
 
 Any file placed in `static/` should be referenced using the absolute URL `/static/[filename]`. If you change `assetSubDirectory` to `assets`, then these URLs will need to be changed to `/assets/[filename]`.
 
-We will learn more about the config file in the [next section](backend.md).
+We will learn more about the config file in the section about [backend integration](backend.md).

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -2,8 +2,10 @@
 
 ``` bash
 .
-├── config.js                   # main project config
 ├── build/                      # webpack config files
+│   └── ...
+├── config/                     
+│   ├── index.js                # main project config
 │   └── ...
 ├── src/
 │   ├── main.js                 # app entry file
@@ -24,18 +26,19 @@
 │   │   ├── runner.js           # test runner script
 │   │   └── nightwatch.conf.js  # test runner config file
 ├── .babelrc                    # babel config
+├── .editorconfig.js            # editor config
 ├── .eslintrc.js                # eslint config
 ├── index.html                  # index.html template
 └── package.json                # build scripts and dependencies
 ```
 
-### `config.js`
-
-This is the main configuration file that exposes some of the most common configuration options for the build setup. See [API Proxying During Development](proxy.md) and [Integrating with Backend Framework](backend.md) for more details.
-
 ### `build/`
 
 This directory holds the actual configurations for both the development server and the production webpack build. Normally you don't need to touch these files unless you want to customize Webpack loaders, in which case you should probably look at `build/webpack.base.conf.js`.
+
+### `config/index.js`
+
+This is the main configuration file that exposes some of the most common configuration options for the build setup. See [API Proxying During Development](proxy.md) and [Integrating with Backend Framework](backend.md) for more details.
 
 ### `src/`
 

--- a/docs/unit.md
+++ b/docs/unit.md
@@ -30,4 +30,4 @@ You can run the tests in multiple real browsers by installing more [karma launch
 
 ## Mocking Dependencies
 
-This boilerplate comes with [inject-laoder](https://github.com/plasticine/inject-loader) installed by default. For usage with `*.vue` components, see [vue-loader docs on testing with mocks](http://vuejs.github.io/vue-loader/workflow/testing-with-mocks.html).
+This boilerplate comes with [inject-loader](https://github.com/plasticine/inject-loader) installed by default. For usage with `*.vue` components, see [vue-loader docs on testing with mocks](http://vue-loader.vuejs.org/en/workflow/testing-with-mocks.html).

--- a/meta.json
+++ b/meta.json
@@ -1,28 +1,28 @@
 {
-  "schema": {
+  "prompts": {
     "name": {
       "type": "string",
       "required": true,
-      "label": "Project name"
+      "message": "Project name"
     },
     "description": {
       "type": "string",
       "required": false,
-      "label": "Project description",
+      "message": "Project description",
       "default": "A Vue.js project"
     },
     "author": {
       "type": "string",
-      "label": "Author"
+      "message": "Author"
     },
     "lint": {
       "type": "confirm",
-      "label": "Use ESLint to lint your code?"
+      "message": "Use ESLint to lint your code?"
     },
     "lintConfig": {
       "when": "lint",
       "type": "list",
-      "label": "Pick an ESLint preset",
+      "message": "Pick an ESLint preset",
       "choices": [
         {
           "name": "Standard (https://github.com/feross/standard)",
@@ -43,11 +43,11 @@
     },
     "unit": {
       "type": "confirm",
-      "label": "Setup unit tests with Karma + Mocha?"
+      "message": "Setup unit tests with Karma + Mocha?"
     },
     "e2e": {
       "type": "confirm",
-      "label": "Setup e2e tests with Nightwatch?"
+      "message": "Setup e2e tests with Nightwatch?"
     }
   },
   "filters": {

--- a/meta.json
+++ b/meta.json
@@ -55,5 +55,5 @@
     "test/unit/**/*": "unit",
     "test/e2e/**/*": "e2e"
   },
-  "completeMessage": "To get started:\n\n  cd {{name}}\n  npm install\n  npm run dev\n\nDocumentation can be found at https://vuejs-templates.github.io/webpack"
+  "completeMessage": "To get started:\n\n  cd {{destDirName}}\n  npm install\n  npm run dev\n\nDocumentation can be found at https://vuejs-templates.github.io/webpack"
 }

--- a/meta.json
+++ b/meta.json
@@ -48,20 +48,12 @@
     "e2e": {
       "type": "confirm",
       "label": "Setup e2e tests with Nightwatch?"
-    },
-    "preprocessors": {
-      "type": "checkbox",
-      "label": "Pre-proccessors",
-      "choices": [
-        "less",
-        "sass",
-        "stylus",
-        "jade"
-      ]
     }
   },
   "filters": {
-    ".eslintrc.js": "lint"
+    ".eslintrc.js": "lint",
+    "test/unit/**/*": "unit",
+    "test/e2e/**/*": "e2e"
   },
   "completeMessage": "To get started:\n\n  cd {{name}}\n  npm install\n  npm run dev\n\nDocumentation can be found at https://vuejs-templates.github.io/webpack"
 }

--- a/meta.json
+++ b/meta.json
@@ -5,12 +5,6 @@
       "required": true,
       "label": "Project name"
     },
-    "version": {
-      "type": "string",
-      "required": true,
-      "label": "Project version",
-      "default": "0.1.0"
-    },
     "description": {
       "type": "string",
       "required": false,
@@ -20,10 +14,6 @@
     "author": {
       "type": "string",
       "label": "Author"
-    },
-    "private": {
-      "type": "boolean",
-      "default": true
     }
   }
 }

--- a/meta.json
+++ b/meta.json
@@ -24,9 +24,21 @@
       "type": "list",
       "label": "Pick an ESLint preset",
       "choices": [
-        "standard (https://github.com/feross/standard)",
-        "airbnb (https://github.com/airbnb/javascript)",
-        "none"
+        {
+          "name": "Standard (https://github.com/feross/standard)",
+          "value": "standard",
+          "short": "Standard"
+        },
+        {
+          "name": "AirBNB (https://github.com/airbnb/javascript)",
+          "value": "airbnb",
+          "short": "AirBNB"
+        },
+        {
+          "name": "none (configure it yourself)",
+          "value": "none",
+          "short": "none"
+        }
       ]
     },
     "unit": {

--- a/meta.json
+++ b/meta.json
@@ -14,6 +14,42 @@
     "author": {
       "type": "string",
       "label": "Author"
+    },
+    "lint": {
+      "type": "confirm",
+      "label": "Use ESLint to lint your code?"
+    },
+    "lintConfig": {
+      "when": "lint",
+      "type": "list",
+      "label": "Pick an ESLint preset",
+      "choices": [
+        "standard (https://github.com/feross/standard)",
+        "airbnb (https://github.com/airbnb/javascript)",
+        "none"
+      ]
+    },
+    "unit": {
+      "type": "confirm",
+      "label": "Setup unit tests with Karma + Mocha?"
+    },
+    "e2e": {
+      "type": "confirm",
+      "label": "Setup e2e tests with Nightwatch?"
+    },
+    "preprocessors": {
+      "type": "checkbox",
+      "label": "Pre-proccessors",
+      "choices": [
+        "less",
+        "sass",
+        "stylus",
+        "jade"
+      ]
     }
-  }
+  },
+  "filters": {
+    ".eslintrc.js": "lint"
+  },
+  "completeMessage": "To get started:\n\n  cd {{name}}\n  npm install\n  npm run dev\n\nDocumentation can be found at https://vuejs-templates.github.io/webpack"
 }

--- a/template/.eslintignore
+++ b/template/.eslintignore
@@ -1,0 +1,2 @@
+build/*.js
+config/*.js

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
   extends: 'standard',
   {{/if_eq}}
   {{#if_eq lintConfig "airbnb"}}
-  extends: 'airbnb/base',
+  extends: 'airbnb-base',
   {{/if_eq}}
   // required to lint *.vue files
   plugins: [

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -1,15 +1,26 @@
 module.exports = {
   root: true,
+  {{#if_eq lintConfig "standard"}}
   // https://github.com/feross/standard/blob/master/RULES.md#javascript-standard-style
   extends: 'standard',
+  {{/if_eq}}
+  {{#if_eq lintConfig "airbnb"}}
+  extends: 'airbnb/base',
+  {{/if_eq}}
   // required to lint *.vue files
   plugins: [
     'html'
   ],
   // add your custom rules here
   'rules': {
+    {{#if_eq lintConfig "standard"}}
     // allow paren-less arrow functions
     'arrow-parens': 0,
+    {{/if_eq}}
+    {{#if_eq lintConfig "airbnb"}}
+    // do not enforce dangling commas
+    'comma-dangle': 0,
+    {{/if_eq}}
     // allow debugger during development
     'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0
   }

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -17,6 +17,9 @@ module.exports = {
     // allow paren-less arrow functions
     'arrow-parens': 0,
     {{/if_eq}}
+    {{#if_eq lintConfig "airbnb"}}
+    'import/no-unresolved': 0,
+    {{/if_eq}}
     // allow debugger during development
     'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0
   }

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -17,10 +17,6 @@ module.exports = {
     // allow paren-less arrow functions
     'arrow-parens': 0,
     {{/if_eq}}
-    {{#if_eq lintConfig "airbnb"}}
-    // do not enforce dangling commas
-    'comma-dangle': 0,
-    {{/if_eq}}
     // allow debugger during development
     'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0
   }

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
   root: true,
+  parserOptions: {
+    sourceType: 'module'
+  },
   {{#if_eq lintConfig "standard"}}
   // https://github.com/feross/standard/blob/master/RULES.md#javascript-standard-style
   extends: 'standard',

--- a/template/README.md
+++ b/template/README.md
@@ -24,4 +24,4 @@ npm run e2e
 npm test
 ```
 
-For detailed explanation on how things work, checkout the [guide](https://github.com/vuejs-templates/webpack#vue-webpack-boilerplate) and [docs for vue-loader](http://vuejs.github.io/vue-loader).
+For detailed explanation on how things work, checkout the [guide](http://vuejs-templates.github.io/webpack/) and [docs for vue-loader](http://vuejs.github.io/vue-loader).

--- a/template/build/dev-client.js
+++ b/template/build/dev-client.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 require('eventsource-polyfill')
 var hotClient = require('webpack-hot-middleware/client?noInfo=true&reload=true')
 

--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -1,4 +1,5 @@
 var path = require('path')
+var url = require('url')
 var express = require('express')
 var webpack = require('webpack')
 var config = require('../config')
@@ -53,7 +54,7 @@ app.use(devMiddleware)
 app.use(hotMiddleware)
 
 // serve pure static assets
-var staticPath = path.join(config.build.assetsPublicPath, config.build.assetsSubDirectory)
+var staticPath = url.resolve(config.build.assetsPublicPath, config.build.assetsSubDirectory)
 app.use(staticPath, express.static('./static'))
 
 module.exports = app.listen(port, function (err) {

--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -1,4 +1,4 @@
-var url = require('url')
+var path = require('path')
 var express = require('express')
 var webpack = require('webpack')
 var config = require('../config')
@@ -53,7 +53,7 @@ app.use(devMiddleware)
 app.use(hotMiddleware)
 
 // serve pure static assets
-var staticPath = url.resolve(config.build.assetsPublicPath, config.build.assetsSubDirectory)
+var staticPath = path.posix.join(config.build.assetsPublicPath, config.build.assetsSubDirectory)
 app.use(staticPath, express.static('./static'))
 
 module.exports = app.listen(port, function (err) {

--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -1,4 +1,3 @@
-var path = require('path')
 var url = require('url')
 var express = require('express')
 var webpack = require('webpack')

--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -40,3 +40,17 @@ exports.cssLoaders = function (options) {
     styl: generateLoaders(['css', 'stylus'])
   }
 }
+
+// Generate loaders for standalone style files (outside of .vue)
+exports.styleLoaders = function (options) {
+  var output = []
+  var loaders = exports.cssLoaders(options)
+  for (var extension in loaders) {
+    var loader = loaders[extension]
+    output.push({
+      test: new RegExp('\\.' + extension + '$'),
+      loader: loader
+    })
+  }
+  return output
+}

--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -1,8 +1,9 @@
+var path = require('path')
 var config = require('../config')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 
-exports.assetsPath = function (path) {
-  return config.build.assetsSubDirectory.replace(/(^\/)|(\/$)/g, '') + '/' + path
+exports.assetsPath = function (_path) {
+  return path.posix.join(config.build.assetsSubDirectory, _path)
 }
 
 exports.cssLoaders = function (options) {

--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -1,6 +1,11 @@
+var config = require('../config')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 
-module.exports = function (options) {
+exports.assetsPath = function (path) {
+  return config.build.assetsSubDirectory.replace(/(^\/)|(\/$)/g, '') + '/' + path
+}
+
+exports.cssLoaders = function (options) {
   options = options || {}
   // generate loader string to be used with extract text plugin
   function generateLoaders (loaders) {

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -18,13 +18,17 @@ module.exports = {
     alias: {
       'src': path.resolve(__dirname, '../src'),
       'assets': path.resolve(__dirname, '../src/assets'),
-      'components': path.resolve(__dirname, '../src/components')
+      'components': path.resolve(__dirname, '../src/components'),
+      'vue': path.resolve(__dirname, '../node_modules/vue/dist/vue.common.js')
     }
   },
   resolveLoader: {
     fallback: [path.join(__dirname, '../node_modules')]
   },
   module: {
+    noParse: [
+      /vue\.common\.js/
+    ],
     {{#lint}}
     preLoaders: [
       {

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -25,6 +25,7 @@ module.exports = {
     fallback: [path.join(__dirname, '../node_modules')]
   },
   module: {
+    {{#lint}}
     preLoaders: [
       {
         test: /\.vue$/,
@@ -39,6 +40,7 @@ module.exports = {
         exclude: /node_modules/
       }
     ],
+    {{/lint}}
     loaders: [
       {
         test: /\.vue$/,
@@ -68,10 +70,12 @@ module.exports = {
       }
     ]
   },
-  vue: {
-    loaders: cssLoaders()
-  },
+  {{#lint}}
   eslint: {
     formatter: require('eslint-friendly-formatter')
+  },
+  {{/lint}}
+  vue: {
+    loaders: cssLoaders()
   }
 }

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -61,11 +61,19 @@ module.exports = {
         loader: 'vue-html'
       },
       {
-        test: /\.(png|jpe?g|gif|svg|woff2?|eot|ttf|otf)(\?.*)?$/,
+        test: /\.(png|jpe?g|gif|svg)(\?.*)?$/,
         loader: 'url',
         query: {
           limit: 10000,
-          name: utils.assetsPath('[name].[hash:7].[ext]')
+          name: utils.assetsPath('img/[name].[hash:7].[ext]')
+        }
+      },
+      {
+        test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
+        loader: 'url',
+        query: {
+          limit: 10000,
+          name: utils.assetsPath('fonts/[name].[hash:7].[ext]')
         }
       }
     ]

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -18,17 +18,13 @@ module.exports = {
     alias: {
       'src': path.resolve(__dirname, '../src'),
       'assets': path.resolve(__dirname, '../src/assets'),
-      'components': path.resolve(__dirname, '../src/components'),
-      'vue': path.resolve(__dirname, '../node_modules/vue/dist/vue.common.js')
+      'components': path.resolve(__dirname, '../src/components')
     }
   },
   resolveLoader: {
     fallback: [path.join(__dirname, '../node_modules')]
   },
   module: {
-    noParse: [
-      /vue\.common\.js/
-    ],
     {{#lint}}
     preLoaders: [
       {

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -1,6 +1,6 @@
 var path = require('path')
 var config = require('../config')
-var cssLoaders = require('./css-loaders')
+var utils = require('./utils')
 var projectRoot = path.resolve(__dirname, '../')
 
 module.exports = {
@@ -65,7 +65,7 @@ module.exports = {
         loader: 'url',
         query: {
           limit: 10000,
-          name: path.join(config.build.assetsSubDirectory, '[name].[hash:7].[ext]')
+          name: utils.assetsPath('[name].[hash:7].[ext]')
         }
       }
     ]
@@ -76,6 +76,6 @@ module.exports = {
   },
   {{/lint}}
   vue: {
-    loaders: cssLoaders()
+    loaders: utils.cssLoaders()
   }
 }

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -1,5 +1,6 @@
 var webpack = require('webpack')
 var merge = require('webpack-merge')
+var utils = require('./utils')
 var baseWebpackConfig = require('./webpack.base.conf')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 
@@ -9,6 +10,9 @@ Object.keys(baseWebpackConfig.entry).forEach(function (name) {
 })
 
 module.exports = merge(baseWebpackConfig, {
+  module: {
+    loaders: utils.styleLoaders()
+  },
   // eval-source-map is faster for development
   devtool: '#eval-source-map',
   plugins: [

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -1,3 +1,4 @@
+var config = require('../config')
 var webpack = require('webpack')
 var merge = require('webpack-merge')
 var utils = require('./utils')
@@ -16,6 +17,9 @@ module.exports = merge(baseWebpackConfig, {
   // eval-source-map is faster for development
   devtool: '#eval-source-map',
   plugins: [
+    new webpack.DefinePlugin({
+      'process.env': config.dev.env
+    }),
     // https://github.com/glenjamin/webpack-hot-middleware#installation--usage
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -65,6 +65,7 @@ module.exports = merge(baseWebpackConfig, {
         // any required modules inside node_modules are extracted to vendor
         return (
           module.resource &&
+          /\.js$/.test(module.resource) &&
           module.resource.indexOf(
             path.join(__dirname, '../node_modules')
           ) === 0

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -66,7 +66,7 @@ module.exports = merge(baseWebpackConfig, {
         return (
           module.resource &&
           module.resource.indexOf(
-            path.posix.join(__dirname, '../node_modules')
+            path.join(__dirname, '../node_modules')
           ) === 0
         )
       }

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -1,4 +1,3 @@
-var path = require('path')
 var config = require('../config')
 var utils = require('./utils')
 var webpack = require('webpack')
@@ -8,6 +7,9 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 
 module.exports = merge(baseWebpackConfig, {
+  module: {
+    loaders: utils.styleLoaders({ sourceMap: config.build.productionSourceMap, extract: true })
+  },
   devtool: config.build.productionSourceMap ? '#source-map' : false,
   output: {
     path: config.build.assetsRoot,

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -80,3 +80,23 @@ module.exports = merge(baseWebpackConfig, {
     })
   ]
 })
+
+if (config.build.productionGzip) {
+  var CompressionWebpackPlugin = require('compression-webpack-plugin')
+
+  webpackConfig.plugins.push(
+    new CompressionWebpackPlugin({
+      asset: "[path].gz[query]",
+      algorithm: "gzip",
+      test: new RegExp(
+        '\\.(' +
+        config.build.productionGzipExtensions.join('|') +
+        ')$'
+      ),
+      threshold: 10240,
+      minRatio: 0.8
+    })
+  )
+}
+
+module.exports = webpackConfig

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -1,3 +1,4 @@
+var path = require('path')
 var config = require('../config')
 var utils = require('./utils')
 var webpack = require('webpack')
@@ -52,7 +53,28 @@ module.exports = merge(baseWebpackConfig, {
         removeAttributeQuotes: true
         // more options:
         // https://github.com/kangax/html-minifier#options-quick-reference
+      },
+      // necessary to consistently work with multiple chunks via CommonsChunkPlugin
+      chunksSortMode: 'dependency'
+    }),
+    // split vendor js into its own file
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'vendor',
+      minChunks: function (module, count) {
+        // any required modules inside node_modules are extracted to vendor
+        return (
+          module.resource &&
+          module.resource.indexOf(
+            path.posix.join(__dirname, '../node_modules')
+          ) === 0
+        )
       }
+    }),
+    // extract webpack runtime and module manifest to its own file in order to
+    // prevent vendor hash from being updated whenever app bundle is updated
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'manifest',
+      chunks: ['vendor']
     })
   ]
 })

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -1,9 +1,9 @@
 var path = require('path')
 var config = require('../config')
+var utils = require('./utils')
 var webpack = require('webpack')
 var merge = require('webpack-merge')
 var baseWebpackConfig = require('./webpack.base.conf')
-var cssLoaders = require('./css-loaders')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 
@@ -11,11 +11,11 @@ module.exports = merge(baseWebpackConfig, {
   devtool: config.build.productionSourceMap ? '#source-map' : false,
   output: {
     path: config.build.assetsRoot,
-    filename: path.join(config.build.assetsSubDirectory, '[name].[chunkhash].js'),
-    chunkFilename: path.join(config.build.assetsSubDirectory, '[id].[chunkhash].js')
+    filename: utils.assetsPath('[name].[chunkhash].js'),
+    chunkFilename: utils.assetsPath('[id].[chunkhash].js')
   },
   vue: {
-    loaders: cssLoaders({
+    loaders: utils.cssLoaders({
       sourceMap: config.build.productionSourceMap,
       extract: true
     })
@@ -34,7 +34,7 @@ module.exports = merge(baseWebpackConfig, {
     }),
     new webpack.optimize.OccurenceOrderPlugin(),
     // extract css into its own file
-    new ExtractTextPlugin(path.join(config.build.assetsSubDirectory, '[name].[contenthash].css')),
+    new ExtractTextPlugin(utils.assetsPath('[name].[contenthash].css')),
     // generate dist index.html with correct asset hash for caching.
     // you can customize output by editing /index.html
     // see https://github.com/ampedandwired/html-webpack-plugin

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -6,6 +6,9 @@ var merge = require('webpack-merge')
 var baseWebpackConfig = require('./webpack.base.conf')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
+var env = process.env.NODE_ENV === 'testing'
+  ? require('../config/test.env')
+  : config.build.env
 
 module.exports = merge(baseWebpackConfig, {
   module: {
@@ -26,9 +29,7 @@ module.exports = merge(baseWebpackConfig, {
   plugins: [
     // http://vuejs.github.io/vue-loader/workflow/production.html
     new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: '"production"'
-      }
+      'process.env': env
     }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -10,7 +10,7 @@ var env = process.env.NODE_ENV === 'testing'
   ? require('../config/test.env')
   : config.build.env
 
-module.exports = merge(baseWebpackConfig, {
+var webpackConfig = merge(baseWebpackConfig, {
   module: {
     loaders: utils.styleLoaders({ sourceMap: config.build.productionSourceMap, extract: true })
   },
@@ -86,8 +86,8 @@ if (config.build.productionGzip) {
 
   webpackConfig.plugins.push(
     new CompressionWebpackPlugin({
-      asset: "[path].gz[query]",
-      algorithm: "gzip",
+      asset: '[path].gz[query]',
+      algorithm: 'gzip',
       test: new RegExp(
         '\\.(' +
         config.build.productionGzipExtensions.join('|') +

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -13,8 +13,8 @@ module.exports = merge(baseWebpackConfig, {
   devtool: config.build.productionSourceMap ? '#source-map' : false,
   output: {
     path: config.build.assetsRoot,
-    filename: utils.assetsPath('[name].[chunkhash].js'),
-    chunkFilename: utils.assetsPath('[id].[chunkhash].js')
+    filename: utils.assetsPath('js/[name].[chunkhash].js'),
+    chunkFilename: utils.assetsPath('js/[id].[chunkhash].js')
   },
   vue: {
     loaders: utils.cssLoaders({
@@ -36,7 +36,7 @@ module.exports = merge(baseWebpackConfig, {
     }),
     new webpack.optimize.OccurenceOrderPlugin(),
     // extract css into its own file
-    new ExtractTextPlugin(utils.assetsPath('[name].[contenthash].css')),
+    new ExtractTextPlugin(utils.assetsPath('css/[name].[contenthash].css')),
     // generate dist index.html with correct asset hash for caching.
     // you can customize output by editing /index.html
     // see https://github.com/ampedandwired/html-webpack-plugin

--- a/template/config/dev.env.js
+++ b/template/config/dev.env.js
@@ -1,0 +1,6 @@
+var merge = require('webpack-merge')
+var prodEnv = require('./prod.env')
+
+module.exports = merge(prodEnv, {
+  NODE_ENV: '"development"'
+})

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -9,8 +9,10 @@ module.exports = {
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',
     productionSourceMap: true,
-    // gzip off by default as many popular static hosts such as
-    // surge or netlify already gzip all static assets for you
+    // Gzip off by default as many popular static hosts such as
+    // Surge or Netlify already gzip all static assets for you.
+    // Before setting to `true`, make sure to:
+    // npm install --save-dev compression-webpack-plugin
     productionGzip: false,
     productionGzipExtensions: ['js', 'css']
   },

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -8,7 +8,11 @@ module.exports = {
     assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',
-    productionSourceMap: true
+    productionSourceMap: true,
+    // gzip off by default as many popular static hosts such as
+    // surge or netlify already gzip all static assets for you
+    productionGzip: false,
+    productionGzipExtensions: ['js', 'css']
   },
   dev: {
     env: require('./dev.env'),

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -3,13 +3,15 @@ var path = require('path')
 
 module.exports = {
   build: {
-    index: path.resolve(__dirname, 'dist/index.html'),
-    assetsRoot: path.resolve(__dirname, 'dist'),
+    env: require('./prod.env'),
+    index: path.resolve(__dirname, '../dist/index.html'),
+    assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',
     productionSourceMap: true
   },
   dev: {
+    env: require('./dev.env'),
     port: 8080,
     proxyTable: {}
   }

--- a/template/config/prod.env.js
+++ b/template/config/prod.env.js
@@ -1,0 +1,3 @@
+module.exports = {
+  NODE_ENV: '"production"'
+}

--- a/template/config/test.env.js
+++ b/template/config/test.env.js
@@ -1,0 +1,6 @@
+var merge = require('webpack-merge')
+var devEnv = require('./dev.env')
+
+module.exports = merge(devEnv, {
+  NODE_ENV: '"testing"'
+})

--- a/template/package.json
+++ b/template/package.json
@@ -48,6 +48,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.4",
     "function-bind": "^1.0.2",
+    "compression-webpack-plugin": "^0.3.1",
     "html-webpack-plugin": "^2.8.1",
     "http-proxy-middleware": "^0.12.0",
     "json-loader": "^0.5.4",

--- a/template/package.json
+++ b/template/package.json
@@ -29,12 +29,17 @@
     "css-loader": "^0.23.0",
     {{#lint}}
     "eslint": "^2.0.0",
-    "eslint-config-standard": "^5.1.0",
     "eslint-friendly-formatter": "^1.2.2",
     "eslint-loader": "^1.3.0",
     "eslint-plugin-html": "^1.3.0",
+    {{#if_eq lintConfig "standard"}}
+    "eslint-config-standard": "^5.1.0",
     "eslint-plugin-promise": "^1.0.8",
     "eslint-plugin-standard": "^1.3.2",
+    {{/if_eq}}
+    {{#if_eq lintConfig "airbnb"}}
+    "eslint-config-airbnb": "^6.2.0",
+    {{/if_eq}}
     {{/lint}}
     "eventsource-polyfill": "^0.9.6",
     "express": "^4.13.3",

--- a/template/package.json
+++ b/template/package.json
@@ -29,8 +29,8 @@
     "connect-history-api-fallback": "^1.1.0",
     "css-loader": "^0.23.0",
     {{#lint}}
-    "eslint": "^2.0.0",
-    "eslint-friendly-formatter": "^1.2.2",
+    "eslint": "^2.10.2",
+    "eslint-friendly-formatter": "^2.0.5",
     "eslint-loader": "^1.3.0",
     "eslint-plugin-html": "^1.3.0",
     {{#if_eq lintConfig "standard"}}
@@ -39,7 +39,8 @@
     "eslint-plugin-standard": "^1.3.2",
     {{/if_eq}}
     {{#if_eq lintConfig "airbnb"}}
-    "eslint-config-airbnb": "^6.2.0",
+    "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-plugin-import": "^1.8.1",
     {{/if_eq}}
     {{/lint}}
     "eventsource-polyfill": "^0.9.6",

--- a/template/package.json
+++ b/template/package.json
@@ -9,7 +9,8 @@
     "build": "node build/build.js",
     "unit": "karma start test/unit/karma.conf.js --single-run",
     "e2e": "node test/e2e/runner.js",
-    "test": "npm run unit && npm run e2e"
+    "test": "npm run unit && npm run e2e"{{#lint}},
+    "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"{{/lint}}
   },
   "dependencies": {
     "vue": "^1.0.18",
@@ -26,6 +27,7 @@
     "connect-history-api-fallback": "^1.1.0",
     "cross-spawn": "^2.1.5",
     "css-loader": "^0.23.0",
+    {{#lint}}
     "eslint": "^2.0.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-friendly-formatter": "^1.2.2",
@@ -33,6 +35,7 @@
     "eslint-plugin-html": "^1.3.0",
     "eslint-plugin-promise": "^1.0.8",
     "eslint-plugin-standard": "^1.3.2",
+    {{/lint}}
     "eventsource-polyfill": "^0.9.6",
     "express": "^4.13.3",
     "extract-text-webpack-plugin": "^1.0.1",

--- a/template/package.json
+++ b/template/package.json
@@ -48,7 +48,6 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.4",
     "function-bind": "^1.0.2",
-    "compression-webpack-plugin": "^0.3.1",
     "html-webpack-plugin": "^2.8.1",
     "http-proxy-middleware": "^0.12.0",
     "json-loader": "^0.5.4",

--- a/template/package.json
+++ b/template/package.json
@@ -17,8 +17,8 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"{{/lint}}
   },
   "dependencies": {
-    "vue": "^1.0.18",
-    "babel-runtime": "^5.8.0"
+    "vue": "^1.0.21",
+    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.0.0",
@@ -79,7 +79,7 @@
     "url-loader": "^0.5.7",
     "vue-hot-reload-api": "^1.2.0",
     "vue-html-loader": "^1.0.0",
-    "vue-loader": "^8.2.1",
+    "vue-loader": "^8.3.0",
     "vue-style-loader": "^1.0.0",
     "webpack": "^1.12.2",
     "webpack-dev-middleware": "^1.4.0",

--- a/template/package.json
+++ b/template/package.json
@@ -1,11 +1,9 @@
 {
   "name": "{{ name }}",
-  "version": "{{ version }}",
+  "version": "1.0.0",
   "description": "{{ description }}",
   "author": "{{ author }}",
-  {{#private}}
   "private": true,
-  {{/private}}
   "scripts": {
     "dev": "node build/dev-server.js",
     "build": "node build/build.js",

--- a/template/package.json
+++ b/template/package.json
@@ -7,9 +7,13 @@
   "scripts": {
     "dev": "node build/dev-server.js",
     "build": "node build/build.js",
+    {{#unit}}
     "unit": "karma start test/unit/karma.conf.js --single-run",
+    {{/unit}}
+    {{#e2e}}
     "e2e": "node test/e2e/runner.js",
-    "test": "npm run unit && npm run e2e"{{#lint}},
+    {{/e2e}}
+    "test": "{{#unit}}npm run unit{{/unit}}{{#unit}}{{#e2e}} && {{/e2e}}{{/unit}}{{#e2e}}npm run e2e{{/e2e}}"{{#lint}},
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"{{/lint}}
   },
   "dependencies": {
@@ -22,10 +26,7 @@
     "babel-plugin-transform-runtime": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",
     "babel-preset-stage-2": "^6.0.0",
-    "chai": "^3.5.0",
-    "chromedriver": "^2.21.2",
     "connect-history-api-fallback": "^1.1.0",
-    "cross-spawn": "^2.1.5",
     "css-loader": "^0.23.0",
     {{#lint}}
     "eslint": "^2.0.0",
@@ -48,9 +49,8 @@
     "function-bind": "^1.0.2",
     "html-webpack-plugin": "^2.8.1",
     "http-proxy-middleware": "^0.12.0",
-    "inject-loader": "^2.0.1",
-    "isparta-loader": "^2.0.0",
     "json-loader": "^0.5.4",
+    {{#unit}}
     "karma": "^0.13.15",
     "karma-coverage": "^0.5.5",
     "karma-mocha": "^0.2.2",
@@ -61,13 +61,21 @@
     "karma-webpack": "^1.7.0",
     "lolex": "^1.4.0",
     "mocha": "^2.4.5",
-    "nightwatch": "^0.8.18",
-    "ora": "^0.2.0",
-    "phantomjs-prebuilt": "^2.1.3",
-    "selenium-server": "2.53.0",
-    "shelljs": "^0.6.0",
+    "chai": "^3.5.0",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
+    "inject-loader": "^2.0.1",
+    "isparta-loader": "^2.0.0",
+    "phantomjs-prebuilt": "^2.1.3",
+    {{/unit}}
+    {{#e2e}}
+    "chromedriver": "^2.21.2",
+    "cross-spawn": "^2.1.5",
+    "nightwatch": "^0.8.18",
+    "selenium-server": "2.53.0",
+    {{/e2e}}
+    "ora": "^0.2.0",
+    "shelljs": "^0.6.0",
     "url-loader": "^0.5.7",
     "vue-hot-reload-api": "^1.2.0",
     "vue-html-loader": "^1.0.0",

--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -23,13 +23,13 @@
 </template>
 
 <script>
-import Hello from './components/Hello'
+import Hello from './components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 export default {
   components: {
     Hello
   }
-}
+}{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 </script>
 
 <style>

--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -27,8 +27,8 @@ import Hello from './components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 export default {
   components: {
-    Hello
-  }
+    Hello{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+  }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
 }{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 </script>
 

--- a/template/src/components/Hello.vue
+++ b/template/src/components/Hello.vue
@@ -6,16 +6,16 @@
 
 <script>
 export default {
-  data () {
+  data{{#unless_eq lintConfig "airbnb"}} {{/unless_eq}}() {
     return {
       // note: changing this line won't causes changes
       // with hot-reload because the reloaded component
       // preserves its current state and we are modifying
       // its initial state.
       msg: 'Hello World!'
-    }
+    }{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
   }
-}
+}{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/template/src/components/Hello.vue
+++ b/template/src/components/Hello.vue
@@ -12,9 +12,9 @@ export default {
       // with hot-reload because the reloaded component
       // preserves its current state and we are modifying
       // its initial state.
-      msg: 'Hello World!'
+      msg: 'Hello World!'{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
     }{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-  }
+  }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
 }{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 </script>
 

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -4,5 +4,5 @@ import App from './App'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 /* eslint-disable no-new */
 new Vue({
   el: 'body',
-  components: { App }
+  components: { App }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
 }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -1,8 +1,8 @@
-import Vue from 'vue'
-import App from './App'
+import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import App from './App'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 /* eslint-disable no-new */
 new Vue({
   el: 'body',
   components: { App }
-})
+}){{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/test/e2e/runner.js
+++ b/template/test/e2e/runner.js
@@ -6,19 +6,19 @@ var server = require('../../build/dev-server.js')
 // to run in additional browsers:
 //    1. add an entry in test/e2e/nightwatch.conf.json under "test_settings"
 //    2. add it to the --env flag below
+// or override the environment flag, for example: `npm run e2e -- --env chrome,firefox`
 // For more information on Nightwatch's config file, see
 // http://nightwatchjs.org/guide#settings-file
+var opts = process.argv.slice(2)
+if (opts.indexOf('--config') === -1) {
+  opts = opts.concat(['--config', 'test/e2e/nightwatch.conf.js'])
+}
+if (opts.indexOf('--env') === -1) {
+  opts = opts.concat(['--env', 'chrome'])
+}
+
 var spawn = require('cross-spawn')
-var runner = spawn(
-  './node_modules/.bin/nightwatch',
-  [
-    '--config', 'test/e2e/nightwatch.conf.js',
-    '--env', 'chrome,firefox'
-  ],
-  {
-    stdio: 'inherit'
-  }
-)
+var runner = spawn('./node_modules/.bin/nightwatch', opts, { stdio: 'inherit' })
 
 runner.on('exit', function (code) {
   server.close()

--- a/template/test/unit/karma.conf.js
+++ b/template/test/unit/karma.conf.js
@@ -7,6 +7,7 @@ var path = require('path')
 var merge = require('webpack-merge')
 var baseConfig = require('../../build/webpack.base.conf')
 var utils = require('../../build/utils')
+var webpack = require('webpack')
 var projectRoot = path.resolve(__dirname, '../../')
 
 var webpackConfig = merge(baseConfig, {
@@ -19,7 +20,12 @@ var webpackConfig = merge(baseConfig, {
     loaders: {
       js: 'isparta'
     }
-  }
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': require('../../config/test.env')
+    })
+  ]
 })
 
 // no need for app entry during tests

--- a/template/test/unit/karma.conf.js
+++ b/template/test/unit/karma.conf.js
@@ -30,14 +30,13 @@ webpackConfig.module.preLoaders = webpackConfig.module.preLoaders || []
 webpackConfig.module.preLoaders.unshift({
   test: /\.js$/,
   loader: 'isparta',
-  include: projectRoot,
-  exclude: /test\/unit|node_modules/
+  include: path.resolve(projectRoot, 'src')
 })
 
 // only apply babel for test files when using isparta
 webpackConfig.module.loaders.some(function (loader, i) {
   if (loader.loader === 'babel') {
-    loader.include = /test\/unit/
+    loader.include = path.resolve(projectRoot, 'test/unit')
     return true
   }
 })

--- a/template/test/unit/karma.conf.js
+++ b/template/test/unit/karma.conf.js
@@ -12,7 +12,7 @@ var projectRoot = path.resolve(__dirname, '../../')
 var webpackConfig = merge(baseConfig, {
   // use inline sourcemap for karma-sourcemap-loader
   module: {
-    loaders: utils.styleLoaders
+    loaders: utils.styleLoaders()
   },
   devtool: '#inline-source-map',
   vue: {

--- a/template/test/unit/karma.conf.js
+++ b/template/test/unit/karma.conf.js
@@ -6,10 +6,14 @@
 var path = require('path')
 var merge = require('webpack-merge')
 var baseConfig = require('../../build/webpack.base.conf')
+var utils = require('../../build/utils')
 var projectRoot = path.resolve(__dirname, '../../')
 
 var webpackConfig = merge(baseConfig, {
   // use inline sourcemap for karma-sourcemap-loader
+  module: {
+    loaders: utils.styleLoaders
+  },
   devtool: '#inline-source-map',
   vue: {
     loaders: {


### PR DESCRIPTION
I used to code in st3 with a plugin `eslint`, and I now code with vscode also get a plugin work with eslint. I will get linter error within the editor, I think it is necessary to config the `.eslintignore` file? how do you guys think?