### PR TITLE
add eslint ignore

### DIFF
--- a/template/.eslintignore
+++ b/template/.eslintignore
@@ -1,0 +1,2 @@
+build/*.js
+config/*.js


### PR DESCRIPTION
I used to code in st3 with a plugin eslint, and I now code with vscode also get a plugin work with eslint. I will get linter error within the editor, I think it is necessary to config the `.eslintignore` file? how do you guys think?