### PR TITLE
Conditional server path

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -53,7 +53,7 @@ app.use(devMiddleware)
 app.use(hotMiddleware)
 
 // serve pure static assets
-var staticPath = path.posix.join(config.build.assetsPublicPath, config.build.assetsSubDirectory)
+var staticPath = path.posix.join(config.dev.assetsPublicPath, config.dev.assetsSubDirectory)
 app.use(staticPath, express.static('./static'))
 
 module.exports = app.listen(port, function (err) {

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -9,7 +9,7 @@ module.exports = {
   },
   output: {
     path: config.build.assetsRoot,
-    publicPath: config.build.assetsPublicPath,
+    publicPath: process.env.NODE_ENV === 'production' ? config.build.assetsPublicPath : config.dev.assetsPublicPath,
     filename: '[name].js'
   },
   resolve: {

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -19,6 +19,8 @@ module.exports = {
   dev: {
     env: require('./dev.env'),
     port: 8080,
+    assetsSubDirectory: 'static',
+    assetsPublicPath: '/',
     proxyTable: {}
   }
 }


### PR DESCRIPTION
This patch will fix an existing issue with dev paths getting mixed up with build paths when defining a different build location.
 
Related issues: #98, #103, #177