### PR TITLE
Add an option to config/index.js to enable CSS Sourcemaps in development

### DIFF
--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -12,7 +12,7 @@ Object.keys(baseWebpackConfig.entry).forEach(function (name) {
 
 module.exports = merge(baseWebpackConfig, {
   module: {
-    loaders: utils.styleLoaders(sourceMap: config.developmentSourceMap)
+    loaders: utils.styleLoaders({ sourceMap: config.dev.developmentSourceMap })
   },
   // eval-source-map is faster for development
   devtool: '#eval-source-map',

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -12,7 +12,7 @@ Object.keys(baseWebpackConfig.entry).forEach(function (name) {
 
 module.exports = merge(baseWebpackConfig, {
   module: {
-    loaders: utils.styleLoaders()
+    loaders: utils.styleLoaders(sourceMap: config.developmentSourceMap)
   },
   // eval-source-map is faster for development
   devtool: '#eval-source-map',

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -12,7 +12,7 @@ Object.keys(baseWebpackConfig.entry).forEach(function (name) {
 
 module.exports = merge(baseWebpackConfig, {
   module: {
-    loaders: utils.styleLoaders({ sourceMap: config.dev.developmentSourceMap })
+    loaders: utils.styleLoaders({ sourceMap: config.dev.cssSourceMap })
   },
   // eval-source-map is faster for development
   devtool: '#eval-source-map',

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -19,6 +19,12 @@ module.exports = {
   dev: {
     env: require('./dev.env'),
     port: 8080,
-    proxyTable: {}
+    proxyTable: {},
+    // Sourcemaps are deactived by default because according to the
+    // CSS-Loader README (https://github.com/webpack/css-loader#sourcemaps),
+    // this option has problems with relative paths.
+    // In out experience, they generally work as expeted, but be aware of this issue when enabling this option.
+    // See also this issue: https://github.com/vuejs-templates/webpack/issues/123
+    developmentSourceMap: false,
   }
 }

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -20,12 +20,11 @@ module.exports = {
     env: require('./dev.env'),
     port: 8080,
     proxyTable: {},
-    // Sourcemaps are deactived by default because
-    // relative paths are "buggy" with this option, according to the
-    // CSS-Loader README (https://github.com/webpack/css-loader#sourcemaps),
-    //
-    // In our experience, they generally work as expeted,
-    // justr but be aware of this issue when enabling this option.
+    // Sourcemaps off by default because relative paths are "buggy"
+    // with this option, according to the CSS-Loader README
+    // (https://github.com/webpack/css-loader#sourcemaps)
+    // In our experience, they generally work as expexted,
+    // just but be aware of this issue when enabling this option.
     // Repated issue in the templates repository:
     // https://github.com/vuejs-templates/webpack/issues/123
     developmentSourceMap: false,

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -27,8 +27,6 @@ module.exports = {
     // (https://github.com/webpack/css-loader#sourcemaps)
     // In our experience, they generally work as expected,
     // just be aware of this issue when enabling this option.
-    // Related issue in the template's repository:
-    // https://github.com/vuejs-templates/webpack/issues/123
     cssSourceMap: false,
   }
 }

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -22,13 +22,13 @@ module.exports = {
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',
     proxyTable: {},
-    // Sourcemaps off by default because relative paths are "buggy"
+    // CSS Sourcemaps off by default because relative paths are "buggy"
     // with this option, according to the CSS-Loader README
     // (https://github.com/webpack/css-loader#sourcemaps)
     // In our experience, they generally work as expected,
     // just be aware of this issue when enabling this option.
     // Related issue in the template's repository:
     // https://github.com/vuejs-templates/webpack/issues/123
-    developmentSourceMap: false,
+    cssSourceMap: false,
   }
 }

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -23,9 +23,9 @@ module.exports = {
     // Sourcemaps off by default because relative paths are "buggy"
     // with this option, according to the CSS-Loader README
     // (https://github.com/webpack/css-loader#sourcemaps)
-    // In our experience, they generally work as expexted,
-    // just but be aware of this issue when enabling this option.
-    // Repated issue in the templates repository:
+    // In our experience, they generally work as expected,
+    // just be aware of this issue when enabling this option.
+    // Related issue in the template's repository:
     // https://github.com/vuejs-templates/webpack/issues/123
     developmentSourceMap: false,
   }

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -20,11 +20,14 @@ module.exports = {
     env: require('./dev.env'),
     port: 8080,
     proxyTable: {},
-    // Sourcemaps are deactived by default because according to the
+    // Sourcemaps are deactived by default because
+    // relative paths are "buggy" with this option, according to the
     // CSS-Loader README (https://github.com/webpack/css-loader#sourcemaps),
-    // this option has problems with relative paths.
-    // In out experience, they generally work as expeted, but be aware of this issue when enabling this option.
-    // See also this issue: https://github.com/vuejs-templates/webpack/issues/123
+    //
+    // In our experience, they generally work as expeted,
+    // justr but be aware of this issue when enabling this option.
+    // Repated issue in the templates repository:
+    // https://github.com/vuejs-templates/webpack/issues/123
     developmentSourceMap: false,
   }
 }


### PR DESCRIPTION
### Current behavior

CSS source maps are disabled for development mode in this template because of buggy relative paths in CSS-Loader (https://github.com/vuejs-templates/webpack/issues/123)

But to enable them, one has to manually add set the option in `webpack.dev.conf.js` to true, it involves quite some digging in the webpack config files.

### New Behavior / Improvement

This Pull request adds a `developmentSourceMap` option to `config/index.js`, which is false by default, along with some comments about the css-loader issue described above.

This improves user experience as users can now simply activate CSS sourcemaps from the config file, and are informed about the possibly buggy behaviour instead of stumbling over it after hacking around in `webpack.dev.conf.js`.

```
config: {
  dev: {
    // Sourcemaps off by default because relative paths are "buggy"
    // with this option, according to the CSS-Loader README
    // (https://github.com/webpack/css-loader#sourcemaps)
    // In our experience, they generally work as expexted,
    // just but be aware of this issue when enabling this option.
    // Repated issue in the templates repository:
    // https://github.com/vuejs-templates/webpack/issues/123
    developmentSourceMap: false,
  }
}
```