### PR TITLE
Adding Babel register to Nightwatch conf

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.0.0",
+    "babel-register": "^6.0.0",
     "babel-loader": "^6.0.0",
     "babel-plugin-transform-runtime": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",

--- a/template/package.json
+++ b/template/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "babel-core": "^6.0.0",
-    "babel-register": "^6.0.0",
     {{#lint}}
     "babel-eslint": "^6.1.2",
     {{/lint}}
@@ -30,6 +29,7 @@
     "babel-plugin-transform-runtime": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",
     "babel-preset-stage-2": "^6.0.0",
+    "babel-register": "^6.0.0",
     "connect-history-api-fallback": "^1.1.0",
     "css-loader": "^0.23.0",
     {{#lint}}

--- a/template/test/e2e/nightwatch.conf.js
+++ b/template/test/e2e/nightwatch.conf.js
@@ -1,3 +1,5 @@
+require('babel-core/register');
+
 // http://nightwatchjs.org/guide#settings-file
 module.exports = {
   "src_folders": ["test/e2e/specs"],

--- a/template/test/e2e/nightwatch.conf.js
+++ b/template/test/e2e/nightwatch.conf.js
@@ -1,4 +1,4 @@
-require('babel-core/register');
+require('babel-register')
 
 // http://nightwatchjs.org/guide#settings-file
 module.exports = {


### PR DESCRIPTION
This *one weird trick* allows you to use ES6 syntax with your Nightwatch tests!