### PR TITLE
Add stage-2 support for linting

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     sourceType: 'module'
   },
@@ -19,6 +20,8 @@ module.exports = {
     {{#if_eq lintConfig "standard"}}
     // allow paren-less arrow functions
     'arrow-parens': 0,
+    // allow async-await
+    'generator-star-spacing': 0,
     {{/if_eq}}
     {{#if_eq lintConfig "airbnb"}}
     'import/no-unresolved': 0,

--- a/template/package.json
+++ b/template/package.json
@@ -22,6 +22,9 @@
   },
   "devDependencies": {
     "babel-core": "^6.0.0",
+    {{#lint}}
+    "babel-eslint": "^6.1.2",
+    {{/lint}}
     "babel-loader": "^6.0.0",
     "babel-plugin-transform-runtime": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",


### PR DESCRIPTION
## Introduction

Currently, ES7 stage 2 features are enabled in `.babelrc`. However, they cannot be used with linting because basic ESLint cannot handle them.

This patch enable ESLint to recognise them using `babel-eslint` parser.

- https://github.com/babel/babel-eslint

## Reproduction

1. Init with linting (standard or airbnb)
2. Add async-await or object spread operator in any source file (I tested with `main.js`)
3. Try building or launching dev server

## Demo

![reproduction](https://cloud.githubusercontent.com/assets/1013641/16899209/3df3b0b8-4c36-11e6-943c-db9402679db1.gif)

Issue reproduction

![resolved](https://cloud.githubusercontent.com/assets/1013641/16899211/52ce0da8-4c36-11e6-9fa0-f610f015f161.gif)

Resolved after applying this patch