### PR TITLE
Add a .gitattributes file

### DIFF
--- a/template/.gitattributes
+++ b/template/.gitattributes
@@ -1,0 +1,3 @@
+* text eol=lf
+*.png binary
+*.jpg binary


### PR DESCRIPTION
Always set the line-endings to `lf`.
The ESLint Airbnb config will fail on Windows due to a recent update.

https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js#L77