### PR TITLE
fix #238 for 2.0

### DIFF
--- a/template/test/unit/specs/Hello.spec.js
+++ b/template/test/unit/specs/Hello.spec.js
@@ -1,12 +1,12 @@
-import Vue from 'vue'
-import Hello from 'src/components/Hello'
+import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import Hello from 'src/components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 describe('Hello.vue', () => {
   it('should render correct contents', () => {
     const vm = new Vue({
       el: document.createElement('div'),
-      render: (h) => h(Hello)
-    })
-    expect(vm.$el.querySelector('.hello h1').textContent).to.equal('Hello Vue!')
-  })
-})
+      render: (h) => h(Hello){{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+    }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    expect(vm.$el.querySelector('.hello h1').textContent).to.equal('Hello Vue!'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+  }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+}){{#if_eq lintConfig "airbnb"}};{{/if_eq}}


### PR DESCRIPTION
This adds handlebars helpers to `hello.spec.js` to correct syntax depending on the chosen lint standard

Fixes #238 for 2.0