### PR TITLE
Fix hello spec lint 1.0

### DIFF
--- a/template/test/unit/specs/Hello.spec.js
+++ b/template/test/unit/specs/Hello.spec.js
@@ -8,5 +8,5 @@ describe('Hello.vue', () => {
       components: { Hello }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
     }).$mount(){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
     expect(vm.$el.querySelector('.hello h1').textContent).to.contain('Hello World!'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-  })
-})
+  }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+}){{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/test/unit/specs/Hello.spec.js
+++ b/template/test/unit/specs/Hello.spec.js
@@ -1,12 +1,12 @@
-import Vue from 'vue'
-import Hello from 'src/components/Hello'
+import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import Hello from 'src/components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 describe('Hello.vue', () => {
   it('should render correct contents', () => {
     const vm = new Vue({
       template: '<div><hello></hello></div>',
-      components: { Hello }
-    }).$mount()
-    expect(vm.$el.querySelector('.hello h1').textContent).to.contain('Hello World!')
+      components: { Hello }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+    }).$mount(){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    expect(vm.$el.querySelector('.hello h1').textContent).to.contain('Hello World!'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
   })
 })


### PR DESCRIPTION
This adds handlebars helpers to `hello.spec.js` to correct syntax depending on the chosen lint standard

Fixes #238 for 1.0