### PR TITLE
Fix #237 npm eslint without e2e tests 1.0

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "e2e": "node test/e2e/runner.js",
     {{/e2e}}
     "test": "{{#unit}}npm run unit{{/unit}}{{#unit}}{{#e2e}} && {{/e2e}}{{/unit}}{{#e2e}}npm run e2e{{/e2e}}"{{#lint}},
-    "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"{{/lint}}
+    "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs{{/e2e}}"{{/lint}}
   },
   "dependencies": {
     "vue": "^1.0.21",

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "e2e": "node test/e2e/runner.js",
     {{/e2e}}
     "test": "{{#unit}}npm run unit{{/unit}}{{#unit}}{{#e2e}} && {{/e2e}}{{/unit}}{{#e2e}}npm run e2e{{/e2e}}"{{#lint}},
-    "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs{{/e2e}}"{{/lint}}
+    "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"{{/lint}}
   },
   "dependencies": {
     "vue": "^1.0.21",

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "e2e": "node test/e2e/runner.js",
     {{/e2e}}
     "test": "{{#unit}}npm run unit{{/unit}}{{#unit}}{{#e2e}} && {{/e2e}}{{/unit}}{{#e2e}}npm run e2e{{/e2e}}"{{#lint}},
-    "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"{{/lint}}
+    "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs"{{/e2e}}{{/lint}}
   },
   "dependencies": {
     "vue": "^1.0.21",

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "e2e": "node test/e2e/runner.js",
     {{/e2e}}
     "test": "{{#unit}}npm run unit{{/unit}}{{#unit}}{{#e2e}} && {{/e2e}}{{/unit}}{{#e2e}}npm run e2e{{/e2e}}"{{#lint}},
-    "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs"{{/e2e}}{{/lint}}
+    "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs{{/e2e}}"{{/lint}}
   },
   "dependencies": {
     "vue": "^1.0.21",


### PR DESCRIPTION
Fixes #237 for 1.0 - invalid paths in npm eslint script when not both unit and e2e tests are selected.