### PR TITLE
Fix #237 npm eslint script in 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A full-featured Webpack setup with hot-reload, lint-on-save, unit testing & css extraction.
 
-> This template is Vue 2.0 compatible. For Vue 1.x please look at 1.0 branch.
+> This template is Vue 2.0 compatible. For Vue 1.x use this command: `vue init webpack#1.0 my-project`
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > A full-featured Webpack setup with hot-reload, lint-on-save, unit testing & css extraction.
 
+> This template is Vue 2.0 compatible. For Vue 1.x please look at 1.0 branch.
+
 ## Documentation
 
 Common topics are discussed in the [docs](http://vuejs-templates.github.io/webpack). Make sure to read it!

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -57,10 +57,6 @@ module.exports = {
         loader: 'json'
       },
       {
-        test: /\.html$/,
-        loader: 'vue-html'
-      },
-      {
         test: /\.(png|jpe?g|gif|svg)(\?.*)?$/,
         loader: 'url',
         query: {

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -80,6 +80,11 @@ module.exports = {
   },
   {{/lint}}
   vue: {
-    loaders: utils.cssLoaders()
+    loaders: utils.cssLoaders(),
+    postcss: [
+      require('autoprefixer')({
+        browsers: ['last 2 versions']
+      })
+    ]
   }
 }

--- a/template/index.html
+++ b/template/index.html
@@ -5,7 +5,7 @@
     <title>{{ name }}</title>
   </head>
   <body>
-    <app></app>
+    <div id="app"></div>
     <!-- built files will be auto injected -->
   </body>
 </html>

--- a/template/package.json
+++ b/template/package.json
@@ -83,7 +83,6 @@
     "shelljs": "^0.6.0",
     "url-loader": "^0.5.7",
     "vue-hot-reload-api": "^1.2.0",
-    "vue-html-loader": "^1.0.0",
     "vue-loader": "^9.4.0",
     "webpack": "^1.12.2",
     "webpack-dev-middleware": "^1.4.0",

--- a/template/package.json
+++ b/template/package.json
@@ -17,10 +17,11 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"{{/lint}}
   },
   "dependencies": {
-    "vue": "^2.0.0-rc.3",
+    "vue": "^2.0.0-rc.4",
     "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
+    "autoprefixer": "^6.4.0",
     "babel-core": "^6.0.0",
     {{#lint}}
     "babel-eslint": "^6.1.2",

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "e2e": "node test/e2e/runner.js",
     {{/e2e}}
     "test": "{{#unit}}npm run unit{{/unit}}{{#unit}}{{#e2e}} && {{/e2e}}{{/unit}}{{#e2e}}npm run e2e{{/e2e}}"{{#lint}},
-    "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"{{/lint}}
+    "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs"{{/e2e}}{{/lint}}
   },
   "dependencies": {
     "vue": "^2.0.0-rc.4",

--- a/template/package.json
+++ b/template/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"{{/lint}}
   },
   "dependencies": {
-    "vue": "^1.0.21",
+    "vue": "^2.0.0-rc.2",
     "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
@@ -84,7 +84,7 @@
     "url-loader": "^0.5.7",
     "vue-hot-reload-api": "^1.2.0",
     "vue-html-loader": "^1.0.0",
-    "vue-loader": "^8.3.0",
+    "vue-loader": "^9.3.2",
     "vue-style-loader": "^1.0.0",
     "webpack": "^1.12.2",
     "webpack-dev-middleware": "^1.4.0",

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "e2e": "node test/e2e/runner.js",
     {{/e2e}}
     "test": "{{#unit}}npm run unit{{/unit}}{{#unit}}{{#e2e}} && {{/e2e}}{{/unit}}{{#e2e}}npm run e2e{{/e2e}}"{{#lint}},
-    "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs"{{/e2e}}{{/lint}}
+    "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs{{/e2e}}"{{/lint}}
   },
   "dependencies": {
     "vue": "^2.0.0-rc.4",

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "e2e": "node test/e2e/runner.js",
     {{/e2e}}
     "test": "{{#unit}}npm run unit{{/unit}}{{#unit}}{{#e2e}} && {{/e2e}}{{/unit}}{{#e2e}}npm run e2e{{/e2e}}"{{#lint}},
-    "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs"{{/e2e}}{{/lint}}
+    "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"{{/lint}}
   },
   "dependencies": {
     "vue": "^2.0.0-rc.4",

--- a/template/package.json
+++ b/template/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"{{/lint}}
   },
   "dependencies": {
-    "vue": "^2.0.0-rc.2",
+    "vue": "^2.0.0-rc.3",
     "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
@@ -84,8 +84,7 @@
     "url-loader": "^0.5.7",
     "vue-hot-reload-api": "^1.2.0",
     "vue-html-loader": "^1.0.0",
-    "vue-loader": "^9.3.2",
-    "vue-style-loader": "^1.0.0",
+    "vue-loader": "^9.4.0",
     "webpack": "^1.12.2",
     "webpack-dev-middleware": "^1.4.0",
     "webpack-hot-middleware": "^2.6.0",

--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <img class="logo" :src="logo">
+    <img class="logo" src="./assets/logo.png">
     <hello></hello>
     <p>
       Welcome to your Vue.js app!
@@ -26,11 +26,6 @@
 import Hello from './components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 export default {
-  data () {
-    return {
-      logo: require('./assets/logo.png')
-    }
-  },
   components: {
     Hello{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
   }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}

--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <img class="logo" src="./assets/logo.png">
+    <img class="logo" :src="logo">
     <hello></hello>
     <p>
       Welcome to your Vue.js app!
@@ -26,6 +26,11 @@
 import Hello from './components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 export default {
+  data () {
+    return {
+      logo: require('./assets/logo.png')
+    }
+  },
   components: {
     Hello{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
   }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}

--- a/template/src/components/Hello.vue
+++ b/template/src/components/Hello.vue
@@ -8,11 +8,7 @@
 export default {
   data{{#unless_eq lintConfig "airbnb"}} {{/unless_eq}}() {
     return {
-      // note: changing this line won't causes changes
-      // with hot-reload because the reloaded component
-      // preserves its current state and we are modifying
-      // its initial state.
-      msg: 'Hello World!'{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+      msg: 'Hello Vue!'{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
     }{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
   }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
 }{{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -3,6 +3,6 @@ import App from './App'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 /* eslint-disable no-new */
 new Vue({
-  el: 'body',
-  components: { App }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+  el: '#app',
+  render: h => h(App){{#if_eq lintConfig "airbnb"}},{{/if_eq}}
 }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/test/e2e/specs/test.js
+++ b/template/test/e2e/specs/test.js
@@ -7,7 +7,7 @@ module.exports = {
     .url('http://localhost:8080')
       .waitForElementVisible('#app', 5000)
       .assert.elementPresent('.logo')
-      .assert.containsText('h1', 'Hello World!')
+      .assert.containsText('h1', 'Hello Vue!')
       .assert.elementCount('p', 3)
       .end()
   }

--- a/template/test/unit/specs/Hello.spec.js
+++ b/template/test/unit/specs/Hello.spec.js
@@ -4,9 +4,9 @@ import Hello from 'src/components/Hello'
 describe('Hello.vue', () => {
   it('should render correct contents', () => {
     const vm = new Vue({
-      template: '<div><hello></hello></div>',
-      components: { Hello }
-    }).$mount()
-    expect(vm.$el.querySelector('.hello h1').textContent).to.contain('Hello World!')
+      el: document.createElement('div'),
+      render: (h) => h(Hello)
+    })
+    expect(vm.$el.querySelector('.hello h1').textContent).to.equal('Hello Vue!')
   })
 })


### PR DESCRIPTION
Fixes #237 for 2.0 - invalid paths in npm eslint script when not both unit and e2e tests are selected.