### PR TITLE
Fix #237 npm eslint script in 2.0

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "e2e": "node test/e2e/runner.js",
     {{/e2e}}
     "test": "{{#unit}}npm run unit{{/unit}}{{#unit}}{{#e2e}} && {{/e2e}}{{/unit}}{{#e2e}}npm run e2e{{/e2e}}"{{#lint}},
-    "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"{{/lint}}
+    "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs"{{/e2e}}{{/lint}}
   },
   "dependencies": {
     "vue": "^2.0.0-rc.4",

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "e2e": "node test/e2e/runner.js",
     {{/e2e}}
     "test": "{{#unit}}npm run unit{{/unit}}{{#unit}}{{#e2e}} && {{/e2e}}{{/unit}}{{#e2e}}npm run e2e{{/e2e}}"{{#lint}},
-    "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs"{{/e2e}}{{/lint}}
+    "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs{{/e2e}}"{{/lint}}
   },
   "dependencies": {
     "vue": "^2.0.0-rc.4",

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "e2e": "node test/e2e/runner.js",
     {{/e2e}}
     "test": "{{#unit}}npm run unit{{/unit}}{{#unit}}{{#e2e}} && {{/e2e}}{{/unit}}{{#e2e}}npm run e2e{{/e2e}}"{{#lint}},
-    "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs"{{/e2e}}{{/lint}}
+    "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"{{/lint}}
   },
   "dependencies": {
     "vue": "^2.0.0-rc.4",


### PR DESCRIPTION
Fixes #237 for 2.0 - invalid paths in npm eslint script when not both unit and e2e tests are selected.