### PR TITLE
[2.0] add nightwatch global with devServer's defined URL:Port (fix #241)

### DIFF
--- a/template/test/e2e/nightwatch.conf.js
+++ b/template/test/e2e/nightwatch.conf.js
@@ -23,7 +23,7 @@ module.exports = {
       "selenium_host": "localhost",
       "silent": true,
       "globals": {
-        "devServerURL": "http://localhost:" + config.dev.port
+        "devServerURL": "http://localhost:" + (process.env.PORT || config.dev.port)
       }
     },
 

--- a/template/test/e2e/nightwatch.conf.js
+++ b/template/test/e2e/nightwatch.conf.js
@@ -23,7 +23,7 @@ module.exports = {
       "selenium_host": "localhost",
       "silent": true,
       "globals": {
-        "devServerURL": "http://localhost" + config.dev.port
+        "devServerURL": "http://localhost:" + config.dev.port
       }
     },
 

--- a/template/test/e2e/nightwatch.conf.js
+++ b/template/test/e2e/nightwatch.conf.js
@@ -1,4 +1,5 @@
 require('babel-register')
+var config = require('../../config')
 
 // http://nightwatchjs.org/guide#settings-file
 module.exports = {
@@ -20,7 +21,10 @@ module.exports = {
     "default": {
       "selenium_port": 4444,
       "selenium_host": "localhost",
-      "silent": true
+      "silent": true,
+      "globals": {
+        "devServerURL": "http://localhost" + config.dev.port
+      }
     },
 
     "chrome": {

--- a/template/test/e2e/specs/test.js
+++ b/template/test/e2e/specs/test.js
@@ -1,13 +1,16 @@
 // For authoring Nightwatch tests, see
 // http://nightwatchjs.org/guide#usage
 
- // see nightwatch.conf.js
- // default: http://localhost:8080
- // automatically uses dev Server port from /config.index.js
-var devServer = browser.globals.devServerURL
+
 
 module.exports = {
   'default e2e tests': function (browser) {
+
+    // automatically uses dev Server port from /config.index.js
+    // default: http://localhost:8080
+    // see nightwatch.conf.js
+    var devServer = browser.globals.devServerURL
+
     browser
     .url(devServer)
       .waitForElementVisible('#app', 5000)

--- a/template/test/e2e/specs/test.js
+++ b/template/test/e2e/specs/test.js
@@ -1,10 +1,15 @@
 // For authoring Nightwatch tests, see
 // http://nightwatchjs.org/guide#usage
 
+ // see nightwatch.conf.js
+ // default: http://localhost:8080
+ // automatically uses dev Server port from /config.index.js
+var devServer = browser.globals.devServerURL
+
 module.exports = {
   'default e2e tests': function (browser) {
     browser
-    .url('http://localhost:8080')
+    .url(devServer)
       .waitForElementVisible('#app', 5000)
       .assert.elementPresent('.logo')
       .assert.containsText('h1', 'Hello Vue!')

--- a/template/test/e2e/specs/test.js
+++ b/template/test/e2e/specs/test.js
@@ -1,8 +1,6 @@
 // For authoring Nightwatch tests, see
 // http://nightwatchjs.org/guide#usage
 
-
-
 module.exports = {
   'default e2e tests': function (browser) {
 


### PR DESCRIPTION
Fix for #241 

This adds the devServer URL as a global and uses the port defined in `/config/index.js` for the URL, _EDIT:_ or, if provided, a PORT environment variable.

in the demo spec file, this global is then used as the target url for the test instead of hardcoding `http//localhost:8080`