### PR TITLE
Add select option to init process: Standalone or runtime-only? (solve #242)

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -15,6 +15,22 @@
       "type": "string",
       "message": "Author"
     },
+    "build": {
+      "type": "list",
+      "Message"
+      "choices": [
+        {
+          "name": "Runtime-only: lighter, but no support for templates defined in .html files (.vue files are fine)",
+          "value": "runtime",
+          "short": "tuntime"
+        },
+        {
+          "name": "Standalone: heavier, because it includes the template parser to allow template in .html files",
+          "value": "standalone",
+          "short": "standalone"
+        }
+      ]
+    },
     "lint": {
       "type": "confirm",
       "message": "Use ESLint to lint your code?"

--- a/meta.json
+++ b/meta.json
@@ -17,7 +17,7 @@
     },
     "build": {
       "type": "list",
-      "Message"
+      "Message": "Vue comes in two build versions, which do you want to use?",
       "choices": [
         {
           "name": "Runtime-only: lighter, but no support for templates defined in .html files (.vue files are fine)",

--- a/meta.json
+++ b/meta.json
@@ -25,7 +25,7 @@
           "short": "tuntime"
         },
         {
-          "name": "Standalone: heavier, because it includes the template parser to allow template in .html files",
+          "name": "Standalone: heavier, because it includes the template parser to allow templates in .html files",
           "value": "standalone",
           "short": "standalone"
         }

--- a/meta.json
+++ b/meta.json
@@ -17,7 +17,7 @@
     },
     "build": {
       "type": "list",
-      "Message": "Vue comes in two build versions, which do you want to use?",
+      "message": "Vue comes in two build versions, which do you want to use?",
       "choices": [
         {
           "name": "Runtime-only: lighter, but no support for templates defined in .html files (.vue files are fine)",

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -16,6 +16,10 @@ module.exports = {
     extensions: ['', '.js', '.vue'],
     fallback: [path.join(__dirname, '../node_modules')],
     alias: {
+      {{#if_eq build "standalone"}}
+      // nessessary to make "import Vue from 'vue'" load the standalone version.
+      'vue': 'vue/dist/vue',
+      {{/if_eq}}
       'src': path.resolve(__dirname, '../src'),
       'assets': path.resolve(__dirname, '../src/assets'),
       'components': path.resolve(__dirname, '../src/components')

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -1,4 +1,4 @@
-{{if_eq build "standalone"}}
+{{#if_eq build "standalone"}}
 // the following line loads the standalone build instead of Runtime-only
 // thanks to an alias defined in /config/webpack.base.conf.js
 // So you don't have to do import Vue from 'vue/dist/vue'

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -1,3 +1,8 @@
+{{if_eq build "standalone"}}
+// the following line loads the standalone build instead of Runtime-only
+// thanks to an alias defined in /config/webpack.base.conf.js
+// So you don't have to do import Vue from 'vue/dist/vue'
+{{/if_eq}}
 import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 import App from './App'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -1,6 +1,7 @@
 {{#if_eq build "standalone"}}
 // The following line loads the standalone build of Vue instead of the runtime-only build,
 // so you don't have to do: import Vue from 'vue/dist/vue'
+// (also, importing Vue standalone this way breaks vue-loader, so don't do it)
 // This is done with an alias defined in /config/webpack.base.conf.js
 {{/if_eq}}
 import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -1,7 +1,7 @@
 {{#if_eq build "standalone"}}
-// the following line loads the standalone build instead of Runtime-only
-// thanks to an alias defined in /config/webpack.base.conf.js
-// So you don't have to do import Vue from 'vue/dist/vue'
+// The following line loads the standalone build of Vue instead of the runtime-only build,
+// so you don't have to do: import Vue from 'vue/dist/vue'
+// This is done with an alias defined in /config/webpack.base.conf.js
 {{/if_eq}}
 import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 import App from './App'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -2,7 +2,7 @@
 // The following line loads the standalone build of Vue instead of the runtime-only build,
 // so you don't have to do: import Vue from 'vue/dist/vue'
 // (also, importing Vue standalone this way breaks vue-loader, so don't do it)
-// This is done with an alias defined in /config/webpack.base.conf.js
+// This is done with an alias defined in /build/webpack.base.conf.js
 {{/if_eq}}
 import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 import App from './App'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}


### PR DESCRIPTION
Solves #242

User can select between the two build versions:
* runtime-only
* standalone

![bildschirmfoto 2016-09-11 um 21 25 16](https://cloud.githubusercontent.com/assets/1444526/18419915/4f959e88-7866-11e6-9437-1ea9cbb9d793.png)

* If "runtime-only" is seleted, nothing happens as this is the default import
* If "standalone" is selected, we add an alias to the webpack conf and a comment in main.js informing the user about this.