### PR TITLE
Optimize babelrc

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,5 +1,13 @@
 {
-  "presets": ["es2015", "stage-2"],
-  "plugins": ["transform-runtime"],
+  "env": {
+    "development": {
+      "presets": ["stage-2"],
+      "plugins": ["transform-es2015-modules-commonjs", "transform-runtime"]
+    },
+    "production": {
+      "presets": ["es2015", "stage-2"],
+      "plugins": ["transform-runtime"]
+    }
+  },
   "comments": false
 }


### PR DESCRIPTION
This is an update to babelrc. 

Most developers when building a web app are using a modern browser and most of modern browsers have much better supports to ES2015 (even better than babel: https://kangax.github.io/compat-table/es6/). Therefore there is no need to translate code to ES2015 in development mode. 

We still need `transform-es2015-modules-commonjs` since webpack and browsers does not support ES6 commonjs modules.
