### PR TITLE
Change webpack alias to work with standalone default export.

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -16,9 +16,11 @@ module.exports = {
     extensions: ['', '.js', '.vue'],
     fallback: [path.join(__dirname, '../node_modules')],
     alias: {
-      {{#if_eq build "standalone"}}
-      // nessessary to make "import Vue from 'vue'" load the standalone version.
+      {{#if_eq build "standalone"}}∞
       'vue': 'vue/dist/vue',
+      {{/if_eq}}
+      {{#if_eq build "runtime"}}∞
+      'vue': 'vue/dist/vue.common.js',
       {{/if_eq}}
       'src': path.resolve(__dirname, '../src'),
       'assets': path.resolve(__dirname, '../src/assets'),

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -1,8 +1,6 @@
-{{#if_eq build "standalone"}}
-// The following line loads the standalone build of Vue instead of the runtime-only build,
-// so you don't have to do: import Vue from 'vue/dist/vue'
-// (also, importing Vue standalone this way breaks vue-loader, so don't do it)
-// This is done with an alias defined in /build/webpack.base.conf.js
+{{#if_eq build "runtime"}}
+// The Vue build version to load with the `import` command
+// (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 {{/if_eq}}
 import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 import App from './App'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}


### PR DESCRIPTION
This should be merged if/when the default export of the Vue 2.0 package is changed to the standalone build.