### PR TITLE
Should copy from static/* instead of static/

### DIFF
--- a/template/build/build.js
+++ b/template/build/build.js
@@ -20,7 +20,7 @@ spinner.start()
 var assetsPath = path.join(config.build.assetsRoot, config.build.assetsSubDirectory)
 rm('-rf', assetsPath)
 mkdir('-p', assetsPath)
-cp('-R', 'static/', assetsPath)
+cp('-R', 'static/*', assetsPath)
 
 webpack(webpackConfig, function (err, stats) {
   spinner.stop()


### PR DESCRIPTION
I am not sure about this, but I think when building for production (via `npm run build`), the script should copy from "static/*" (note extra asterisk) instead of "static/". Please correct me if I am wrong.