### PR TITLE
Resolve imports

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -15,6 +15,16 @@ module.exports = {
   plugins: [
     'html'
   ],
+  {{#if_eq lintConfig "airbnb"}}
+  // check if imports actually resolve
+  'settings': {
+    'import/resolver': {
+      'webpack': {
+        'config': 'build/webpack.base.conf.js'
+      }
+    }
+  },
+  {{/if_eq}}
   // add your custom rules here
   'rules': {
     {{#if_eq lintConfig "standard"}}
@@ -22,9 +32,6 @@ module.exports = {
     'arrow-parens': 0,
     // allow async-await
     'generator-star-spacing': 0,
-    {{/if_eq}}
-    {{#if_eq lintConfig "airbnb"}}
-    'import/no-unresolved': 0,
     {{/if_eq}}
     // allow debugger during development
     'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0

--- a/template/package.json
+++ b/template/package.json
@@ -40,6 +40,7 @@
     {{/if_eq}}
     {{#if_eq lintConfig "airbnb"}}
     "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-import-resolver-webpack": "^0.6.0",
     "eslint-plugin-import": "^1.8.1",
     {{/if_eq}}
     {{/lint}}


### PR DESCRIPTION
This PR adds eslint-import-resolver-webpack so AirBnB's config can resolve imports.

Just wondering, do we want import to not require the .vue extension as well?

I could commit this as well:
```
    {{#if_eq lintConfig "airbnb"}}
    // don't require .vue extension when importing
    'import/extensions': ['error', 'always', {
      'js': 'never',
      'vue': 'never'
    }],
    {{/if_eq}}
```