### PR TITLE
fix vue alias

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -17,10 +17,7 @@ module.exports = {
     fallback: [path.join(__dirname, '../node_modules')],
     alias: {
       {{#if_eq build "standalone"}}
-      'vue': 'vue/dist/vue',
-      {{/if_eq}}
-      {{#if_eq build "runtime"}}
-      'vue': 'vue/dist/vue.common.js',
+      'vue$': 'vue/dist/vue',
       {{/if_eq}}
       'src': path.resolve(__dirname, '../src'),
       'assets': path.resolve(__dirname, '../src/assets'),


### PR DESCRIPTION
1. I removed the alias for the runtime-build as it's not nessessary anymore (It was only a temporary security measure for the time of 2.0 release)
2. improved alias for the standalone build:
```js
//before
vue: 'vue/dist/vue' // =Y this made it impossible to import other files from the /dist directory.

// now
'vue$': 'vue/dist/vue' // Whith this match pattern, other requires are still possible.
```