### PR TITLE
Source maps option for vue css loaders

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -1,3 +1,5 @@
+if (!process.env.NODE_ENV) process.env.NODE_ENV = 'development'
+
 var path = require('path')
 var express = require('express')
 var webpack = require('webpack')
@@ -7,8 +9,6 @@ var proxyMiddleware = require('http-proxy-middleware')
 var webpackConfig = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'
   ? require('./webpack.prod.conf')
   : {{/if_or}}require('./webpack.dev.conf')
-
-if (!process.env.NODE_ENV) process.env.NODE_ENV = 'development'
 
 // default port where dev server listens for incoming traffic
 var port = process.env.PORT || config.dev.port

--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -8,6 +8,8 @@ var webpackConfig = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'
   ? require('./webpack.prod.conf')
   : {{/if_or}}require('./webpack.dev.conf')
 
+if (!process.env.NODE_ENV) process.env.NODE_ENV = 'development'
+
 // default port where dev server listens for incoming traffic
 var port = process.env.PORT || config.dev.port
 // Define HTTP proxies to your custom API backend

--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -1,9 +1,8 @@
-if (!process.env.NODE_ENV) process.env.NODE_ENV = 'development'
-
+var config = require('../config')
+if (!process.env.NODE_ENV) process.env.NODE_ENV = config.dev.env
 var path = require('path')
 var express = require('express')
 var webpack = require('webpack')
-var config = require('../config')
 var opn = require('opn')
 var proxyMiddleware = require('http-proxy-middleware')
 var webpackConfig = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'

--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -25,6 +25,8 @@ exports.cssLoaders = function (options) {
       return loader + (options.sourceMap ? extraParamChar + 'sourceMap' : '')
     }).join('!')
 
+    // Extract CSS when that option is specified
+    // (which is the case during production build)
     if (options.extract) {
       return ExtractTextPlugin.extract('vue-style-loader', sourceLoader)
     } else {

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -3,6 +3,13 @@ var config = require('../config')
 var utils = require('./utils')
 var projectRoot = path.resolve(__dirname, '../')
 
+var env = process.env.NODE_ENV
+
+var cssSourceMapDev = (env === 'development' && config.dev.cssSourceMap)
+var cssSourceMapProd = (env === 'production')
+
+var useCssSourcemap = cssSourceMapDev || cssSourceMapProd
+
 module.exports = {
   entry: {
     app: './src/main.js'
@@ -86,7 +93,7 @@ module.exports = {
   },
   {{/lint}}
   vue: {
-    loaders: utils.cssLoaders(),
+    loaders: utils.cssLoaders({ sourceMap: useCssSourceMap }),
     postcss: [
       require('autoprefixer')({
         browsers: ['last 2 versions']

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -4,11 +4,11 @@ var utils = require('./utils')
 var projectRoot = path.resolve(__dirname, '../')
 
 var env = process.env.NODE_ENV
-
+// check env & config/index.js to decide weither to enable CSS Sourcemaps for the
+// various preprocessor loaders added to vue-loader at the end of this file
 var cssSourceMapDev = (env === 'development' && config.dev.cssSourceMap)
-var cssSourceMapProd = (env === 'production')
-
-var useCssSourcemap = cssSourceMapDev || cssSourceMapProd
+var cssSourceMapProd = (env === 'production' && config.build.productionSourceMap)
+var useCssSourceMap = cssSourceMapDev || cssSourceMapProd
 
 module.exports = {
   entry: {


### PR DESCRIPTION
#### The Problem
Some time ago, I added a `cssSourceMap` option to the dev config in `config/index.js`.

Hwever, I used this config only [here, in webpack.dev.con.js](https://github.com/vuejs-templates/webpack/blob/master/template/build/webpack.dev.conf.js#L15), and not [here, in webpack.base.conf.js](https://github.com/vuejs-templates/webpack/blob/master/template/build/webpack.base.conf.js#L86)

Result: CSS sourcemaps were not created for vue files, only for external files(.scss) required in JS.

### Solution

add this option also in that second place. easy.

Well the challenge was that the css loaders for vue.loader are added in `webpack.base.conf.js`, so I had different environments into account. 

That's why I also explicitly set `process.env.NODE_ENV` in `devServer.js` (unless already defined) - so that I can cleanly check the env in the base config.

If someone has a better solution for this, go ahead! :)