### PR TITLE
add the webpack-md5-hash to optimise the chunkhash

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -6,6 +6,7 @@ var merge = require('webpack-merge')
 var baseWebpackConfig = require('./webpack.base.conf')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
+var WebpackMd5Hash = require('webpack-md5-hash');
 var env = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'
   ? require('../config/test.env')
   : {{/if_or}}config.build.env
@@ -77,7 +78,10 @@ var webpackConfig = merge(baseWebpackConfig, {
     new webpack.optimize.CommonsChunkPlugin({
       name: 'manifest',
       chunks: ['vendor']
-    })
+    }),
+    // optimise the chunkhash
+    // prevent js hash from being updated whenever css files are updated
+    new WebpackMd5Hash()
   ]
 })
 

--- a/template/package.json
+++ b/template/package.json
@@ -85,6 +85,7 @@
     "webpack": "^1.13.2",
     "webpack-dev-middleware": "^1.8.3",
     "webpack-hot-middleware": "^2.12.2",
-    "webpack-merge": "^0.14.1"
+    "webpack-merge": "^0.14.1",
+    "webpack-md5-hash": "0.0.5"
   }
 }


### PR DESCRIPTION
Add the webpack-md5-hash plugin to prevent the js chunkhash being updated when only the css file is being updated.