### PR TITLE
Use a template instead of a render function for users of the standalone template

### DIFF
--- a/template/src/main.js
+++ b/template/src/main.js
@@ -8,5 +8,11 @@ import App from './App'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 /* eslint-disable no-new */
 new Vue({
   el: '#app',
+  {{#if_eq build "runtime"}}
   render: h => h(App){{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+  {{/if_eq}}
+  {{#if_eq build "standalone"}}
+  template: '<App/>',
+  components: { App }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+  {{/if_eq}}
 }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}


### PR DESCRIPTION
As @LinusBorg brought up in a separate PR, this might be a good idea to prevent those (typically less advanced) users from having to learn about render functions right away. Thoughts?