### PR TITLE
Fix references

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -28,7 +28,7 @@ All build commands are executed via [NPM Scripts](https://docs.npmjs.com/misc/sc
 
 - Supports ES2015 in test files.
 - Supports all webpack loaders.
-- Easy [mock injection](http://vuejs.github.io/vue-loader/workflow/testing-with-mocks.html).
+- Easy [mock injection](http://vuejs.github.io/vue-loader/en/workflow/testing-with-mocks.html).
 
 ### `npm run e2e`
 

--- a/docs/pre-processors.md
+++ b/docs/pre-processors.md
@@ -37,7 +37,7 @@ module.exports = {
 }
 ```
 
-See [vue-loader's related documentation](http://vuejs.github.io/vue-loader/features/postcss.html) for more details.
+See [vue-loader's related documentation](http://vuejs.github.io/vue-loader/en/features/postcss.html) for more details.
 
 ### Standalone CSS Files
 

--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -34,7 +34,7 @@ exports.cssLoaders = function (options) {
     }
   }
 
-  // http://vuejs.github.io/vue-loader/configurations/extract-css.html
+  // http://vuejs.github.io/vue-loader/en/configurations/extract-css.html
   return {
     css: generateLoaders(['css']),
     postcss: generateLoaders(['css']),

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -27,7 +27,7 @@ var webpackConfig = merge(baseWebpackConfig, {
     })
   },
   plugins: [
-    // http://vuejs.github.io/vue-loader/workflow/production.html
+    // http://vuejs.github.io/vue-loader/en/workflow/production.html
     new webpack.DefinePlugin({
       'process.env': env
     }),


### PR DESCRIPTION
I kept `vuejs.github.io`, although I saw `vue-loader.vuejs.org` somewhere in the template.