### PR TITLE
Fix: fix e2e test open browser

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -66,5 +66,9 @@ module.exports = app.listen(port, function (err) {
   }
   var uri = 'http://localhost:' + port
   console.log('Listening at ' + uri + '\n')
-  opn(uri)
+
+  // when env is testing, don't need open it
+  if (process.env.NODE_ENV !== 'testing') {
+    opn(uri)
+  }
 })


### PR DESCRIPTION
when use `npm run e2e`, will open browser before test browser opened.