### PR TITLE
Add Vuex and vue-router as options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 docs/_book
+.idea

--- a/meta.js
+++ b/meta.js
@@ -73,6 +73,14 @@ module.exports = {
     "e2e": {
       "type": "confirm",
       "message": "Setup e2e tests with Nightwatch?"
+    },
+    "vuex": {
+      "type": "confirm",
+      "message": "Use Vuex"
+    },
+    "vueRouter": {
+      "type": "confirm",
+      "message": "Use vue-router"
     }
   },
   "filters": {
@@ -80,7 +88,9 @@ module.exports = {
     ".eslintignore": "lint",
     "config/test.env.js": "unit || e2e",
     "test/unit/**/*": "unit",
-    "test/e2e/**/*": "e2e"
+    "test/e2e/**/*": "e2e",
+    "src/router/**/*": "vueRouter",
+    "src/vuex/**/*": "vuex"
   },
   "completeMessage": "To get started:\n\n  cd {{destDirName}}\n  npm install\n  npm run dev\n\nDocumentation can be found at https://vuejs-templates.github.io/webpack"
 };

--- a/template/package.json
+++ b/template/package.json
@@ -13,7 +13,10 @@
     "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs{{/e2e}}"{{/lint}}
   },
   "dependencies": {
-    "vue": "^2.0.1"
+    "vue": "^2.0.1"{{#vueRouter}},
+    "vue-router": "^2.0.1"{{/vueRouter}}{{#vuex}},
+    "vuex": "^2.0.0"{{/vuex}}{{#vueRouter}}{{#vuex}},
+    "vuex-router-sync": "^3.0.0"{{/vuex}}{{/vueRouter}}
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",

--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -1,18 +1,18 @@
 <template>
   <div id="app">
     <img src="./assets/logo.png">
-    <hello></hello>
+    {{#vueRouter}}<router-view></router-view>{{/vueRouter}}{{#if_eq vueRouter false}}<hello></hello>{{/if_eq}}
   </div>
 </template>
 
 <script>
-import Hello from './components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+{{#if_eq vueRouter false}}import Hello from './components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
-export default {
-  name: 'app',
+{{/if_eq}}export default {
+  name: 'app'{{#if_eq vueRouter false}},
   components: {
     Hello{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
-  }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+  }{{/if_eq}}{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
 }{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 </script>
 

--- a/template/src/components/Hello.vue
+++ b/template/src/components/Hello.vue
@@ -16,18 +16,32 @@
       <li><a href="http://vuex.vuejs.org/" target="_blank">vuex</a></li>
       <li><a href="http://vue-loader.vuejs.org/" target="_blank">vue-loader</a></li>
       <li><a href="https://github.com/vuejs/awesome-vue" target="_blank">awesome-vue</a></li>
-    </ul>
+    </ul>{{#vuex}}
+    <h1>Counter: \{{ counter }}</h1>
+    <h2>
+      <button @click="increment">Increment</button>
+    </h2>{{/vuex}}
   </div>
 </template>
 
 <script>
+{{#vuex}}import { mapActions, mapGetters } from 'vuex'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+
+{{/vuex}}
 export default {
-  name: 'hello',
+  name: 'hello'{{#if_eq vuex false}},
   data{{#unless_eq lintConfig "airbnb"}} {{/unless_eq}}() {
     return {
       msg: 'Welcome to Your Vue.js App'{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
     }{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-  }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+  }{{/if_eq}}{{#vuex}},
+  computed: mapGetters([
+    'counter',
+    'msg'{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+  ]),
+  methods: mapActions([
+    'increment'{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+  ]){{/vuex}}{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
 }{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 </script>
 

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -2,12 +2,19 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 {{/if_eq}}
-import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-import App from './App'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}{{#vueRouter}}{{#vuex}}
+import { sync } from 'vuex-router-sync'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}{{/vuex}}{{/vueRouter}}
+import App from './App'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}{{#vueRouter}}
+import router from './router/router'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}{{/vueRouter}}{{#vuex}}
+import store from './vuex/store'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}{{#vueRouter}}
+
+sync(store, router){{#if_eq lintConfig "airbnb"}};{{/if_eq}}{{/vueRouter}}{{/vuex}}
 
 /* eslint-disable no-new */
 new Vue({
-  el: '#app',
+  el: '#app',{{#vueRouter}}
+  router,{{/vueRouter}}{{#vuex}}
+  store,{{/vuex}}
   {{#if_eq build "runtime"}}
   render: h => h(App){{#if_eq lintConfig "airbnb"}},{{/if_eq}}
   {{/if_eq}}

--- a/template/src/router/router.js
+++ b/template/src/router/router.js
@@ -1,0 +1,9 @@
+import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import VueRouter from 'vue-router'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import routes from './routes'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+
+Vue.use(VueRouter){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+
+export default new VueRouter({
+  routes{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+}){{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/src/router/routes.js
+++ b/template/src/router/routes.js
@@ -1,0 +1,8 @@
+import Hello from '../components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+
+export default [
+  {
+    path: '/',
+    component: Hello{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+  }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+]{{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/src/vuex/actions.js
+++ b/template/src/vuex/actions.js
@@ -1,0 +1,5 @@
+export default {
+  increment{{#unless_eq lintConfig "airbnb"}} {{/unless_eq}}({ commit }) {
+    commit('increment'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+  }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+}{{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/src/vuex/getters.js
+++ b/template/src/vuex/getters.js
@@ -1,0 +1,4 @@
+export default {
+  msg: state => state.msg,
+  counter: state => state.counter{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+}{{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/src/vuex/mutations.js
+++ b/template/src/vuex/mutations.js
@@ -1,0 +1,6 @@
+{{#if_eq lintConfig "airbnb"}}/* eslint-disable no-param-reassign */
+{{/if_eq}}export default {
+  increment{{#unless_eq lintConfig "airbnb"}} {{/unless_eq}}(state) {
+    state.counter += 1{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+  }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+}{{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/src/vuex/state.js
+++ b/template/src/vuex/state.js
@@ -1,0 +1,4 @@
+export default {
+  msg: 'Hello from vuex',
+  counter: 0{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+}{{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/src/vuex/store.js
+++ b/template/src/vuex/store.js
@@ -1,0 +1,15 @@
+import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import Vuex from 'vuex'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import state from './state'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import getters from './getters'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import actions from './actions'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import mutations from './mutations'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+
+Vue.use(Vuex){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+
+export default new Vuex.Store({
+  state,
+  getters,
+  actions,
+  mutations{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+}){{#if_eq lintConfig "airbnb"}};{{/if_eq}}


### PR DESCRIPTION
I think we need vuex and vue-router options in a boilerplate. Is here anyone who wants to fix test/docs for this?

P.S. I guess we should show more from vuex, router, test it, document it and make something like webpack-advanced boilerplate for that instead of filling this one.
