### PR TITLE
Fix unit testing (Airbnb style lint)

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -39,6 +39,10 @@ module.exports = {
       'js': 'never',
       'vue': 'never'
     }],
+    // allow optionalDependencies
+    'import/no-extraneous-dependencies': ['error', {
+      'optionalDependencies': ['test/unit/index.js']
+    }],
     {{/if_eq}}
     // allow debugger during development
     'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0

--- a/template/test/unit/specs/Hello.spec.js
+++ b/template/test/unit/specs/Hello.spec.js
@@ -3,10 +3,8 @@ import Hello from 'src/components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}
 
 describe('Hello.vue', () => {
   it('should render correct contents', () => {
-    const vm = new Vue({
-      el: document.createElement('div'),
-      render: (h) => h(Hello){{#if_eq lintConfig "airbnb"}},{{/if_eq}}
-    }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    const Constructor = Vue.extend(Hello){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    const vm = new Constructor().$mount(){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
     expect(vm.$el.querySelector('.hello h1').textContent)
       .to.equal('Welcome to Your Vue.js App'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
   }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}


### PR DESCRIPTION
Hi, I fixed unit testing error (Airbnb style lint error).

I also improved unit testing referring the official guide.

* Unit Testing - vue.js
* https://vuejs.org/v2/guide/unit-testing.html

### Before

It has no error when it is linted with standard style.

But It has several errors linted with airbnb style:

```
ERROR in ./test/unit/index.js

  ✘  https://google.com/#q=import%2Fno-extraneous-dependencies  'function-bind' should be listed in the project's dependencies, not devDependencies 
  /Users/inouetakuya/Projects/vue-webpack/test/unit/index.js:3:27
  Function.prototype.bind = require('function-bind');
                             ^


✘ 1 problem (1 error, 0 warnings)


Errors:
  1  https://google.com/#q=import%2Fno-extraneous-dependencies

ERROR in ./test/unit/specs/Hello.spec.js

  ✘  http://eslint.org/docs/rules/no-undef      'document' is not defined
  /Users/inouetakuya/Projects/vue-webpack/test/unit/specs/Hello.spec.js:7:11
        el: document.createElement('div'),
             ^

  ✘  http://eslint.org/docs/rules/arrow-parens  Unexpected parentheses around single function argument having a body with no curly braces
  /Users/inouetakuya/Projects/vue-webpack/test/unit/specs/Hello.spec.js:8:15
        render: (h) => h(Hello),
                 ^


✘ 2 problems (2 errors, 0 warnings)


Errors:
  1  http://eslint.org/docs/rules/arrow-parens
  1  http://eslint.org/docs/rules/no-undef
```

### After

It works when it is linted with both airbnb style and standard style !!

* https://github.com/inouetakuya/vue-webpack-airbnb/pull/1 (airbnb)
* https://github.com/inouetakuya/vue-webpack-standard/pull/1 (standard)

```
  Hello.vue
    ✓ should render correct contents

PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 1 of 1 SUCCESS (0.015 secs / 0.008 secs)
TOTAL: 1 SUCCESS
```

