### PR TITLE
Moved some devDependencies to dependencies to fix npm i --production

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -13,9 +13,6 @@
     "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs{{/e2e}}"{{/lint}}
   },
   "dependencies": {
-    "vue": "^2.0.1"
-  },
-  "devDependencies": {
     "autoprefixer": "^6.4.0",
     "babel-core": "^6.0.0",
     {{#lint}}
@@ -25,9 +22,6 @@
     "babel-plugin-transform-runtime": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",
     "babel-preset-stage-2": "^6.0.0",
-    "babel-register": "^6.0.0",
-    "chalk": "^1.1.3",
-    "connect-history-api-fallback": "^1.1.0",
     "css-loader": "^0.25.0",
     {{#lint}}
     "eslint": "^3.7.1",
@@ -45,14 +39,28 @@
     "eslint-plugin-import": "^1.16.0",
     {{/if_eq}}
     {{/lint}}
-    "eventsource-polyfill": "^0.9.6",
-    "express": "^4.13.3",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
+    "json-loader": "^0.5.4",
+    "ora": "^0.3.0",
+    "shelljs": "^0.7.4",
+    "url-loader": "^0.5.7",
+    "vue": "^2.0.1",
+    "vue-loader": "^9.4.0",
+    "vue-style-loader": "^1.0.0",
+    "webpack": "^1.13.2",
+    "webpack-dev-middleware": "^1.8.3",
+    "webpack-merge": "^0.14.1"
+  },
+  "devDependencies": {
+    "babel-register": "^6.0.0",
+    "chalk": "^1.1.3",
+    "connect-history-api-fallback": "^1.1.0",
+    "eventsource-polyfill": "^0.9.6",
+    "express": "^4.13.3",
     "function-bind": "^1.0.2",
     "html-webpack-plugin": "^2.8.1",
     "http-proxy-middleware": "^0.17.2",
-    "json-loader": "^0.5.4",
     {{#unit}}
     "karma": "^1.3.0",
     "karma-coverage": "^1.1.1",
@@ -79,15 +87,7 @@
     {{/e2e}}
     "semver": "^5.3.0",
     "opn": "^4.0.2",
-    "ora": "^0.3.0",
-    "shelljs": "^0.7.4",
-    "url-loader": "^0.5.7",
-    "vue-loader": "^9.4.0",
-    "vue-style-loader": "^1.0.0",
-    "webpack": "^1.13.2",
-    "webpack-dev-middleware": "^1.8.3",
-    "webpack-hot-middleware": "^2.12.2",
-    "webpack-merge": "^0.14.1"
+    "webpack-hot-middleware": "^2.12.2"
   },
   "engines": {
     "node": ">= 4.0.0",


### PR DESCRIPTION
Currently, `npm install --production && npm run build` throws an error because it doesn't have the required dependencies. I'm not sure what the system for dependencies vs devDependencies was before, but it doesn't seem that helpful - if it's already built, you don't need the vue dependency, and if it isn't build yet, you need the build dependencies. Seems to be set up to have the dependencies of a library, which it isn't - it's an app template.

This PR moves all the dependencies required for building for production to the `dependencies`.