### PR TITLE
fixed dependency error: eslint-plugin-promise

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-html": "^1.3.0",
     {{#if_eq lintConfig "standard"}}
     "eslint-config-standard": "^6.1.0",
-    "eslint-plugin-promise": "^2.0.1",
+    "eslint-plugin-promise": "^3.3.0",
     "eslint-plugin-standard": "^2.0.1",
     {{/if_eq}}
     {{#if_eq lintConfig "airbnb"}}


### PR DESCRIPTION
fixed dependency error:
```
npm ERR! peerinvalid The package eslint-plugin-promise@2.0.1 does not satisfy its siblings peerDependencies requirements! npm ERR! peerinvalid Peer eslint-config-standard@6.2.1 wants eslint-plugin-promise@>=3.3.0
```