### PR TITLE
Solve eslint warnings; use webpack alias.

### DIFF
--- a/template/test/e2e/nightwatch.conf.js
+++ b/template/test/e2e/nightwatch.conf.js
@@ -3,43 +3,43 @@ var config = require('../../config')
 
 // http://nightwatchjs.org/guide#settings-file
 module.exports = {
-  "src_folders": ["test/e2e/specs"],
-  "output_folder": "test/e2e/reports",
-  "custom_assertions_path": ["test/e2e/custom-assertions"],
+  'src_folders': ['test/e2e/specs'],
+  'output_folder': 'test/e2e/reports',
+  'custom_assertions_path': ['test/e2e/custom-assertions'],
 
-  "selenium": {
-    "start_process": true,
-    "server_path": "node_modules/selenium-server/lib/runner/selenium-server-standalone-2.53.1.jar",
-    "host": "127.0.0.1",
-    "port": 4444,
-    "cli_args": {
-      "webdriver.chrome.driver": require('chromedriver').path
+  'selenium': {
+    'start_process': true,
+    'server_path': 'node_modules/selenium-server/lib/runner/selenium-server-standalone-2.53.1.jar',
+    'host': '127.0.0.1',
+    'port': 4444,
+    'cli_args': {
+      'webdriver.chrome.driver': require('chromedriver').path
     }
   },
 
-  "test_settings": {
-    "default": {
-      "selenium_port": 4444,
-      "selenium_host": "localhost",
-      "silent": true,
-      "globals": {
-        "devServerURL": "http://localhost:" + (process.env.PORT || config.dev.port)
+  'test_settings': {
+    'default': {
+      'selenium_port': 4444,
+      'selenium_host': 'localhost',
+      'silent': true,
+      'globals': {
+        'devServerURL': 'http://localhost:' + (process.env.PORT || config.dev.port)
       }
     },
 
-    "chrome": {
-      "desiredCapabilities": {
-        "browserName": "chrome",
-        "javascriptEnabled": true,
-        "acceptSslCerts": true
+    'chrome': {
+      'desiredCapabilities': {
+        'browserName': 'chrome',
+        'javascriptEnabled': true,
+        'acceptSslCerts': true
       }
     },
 
-    "firefox": {
-      "desiredCapabilities": {
-        "browserName": "firefox",
-        "javascriptEnabled": true,
-        "acceptSslCerts": true
+    'firefox': {
+      'desiredCapabilities': {
+        'browserName': 'firefox',
+        'javascriptEnabled': true,
+        'acceptSslCerts': true
       }
     }
   }

--- a/template/test/e2e/nightwatch.conf.js
+++ b/template/test/e2e/nightwatch.conf.js
@@ -3,43 +3,43 @@ var config = require('../../config')
 
 // http://nightwatchjs.org/guide#settings-file
 module.exports = {
-  'src_folders': ['test/e2e/specs'],
-  'output_folder': 'test/e2e/reports',
-  'custom_assertions_path': ['test/e2e/custom-assertions'],
+  src_folders: ['test/e2e/specs'],
+  output_folder: 'test/e2e/reports',
+  custom_assertions_path: ['test/e2e/custom-assertions'],
 
-  'selenium': {
-    'start_process': true,
-    'server_path': 'node_modules/selenium-server/lib/runner/selenium-server-standalone-2.53.1.jar',
-    'host': '127.0.0.1',
-    'port': 4444,
-    'cli_args': {
+  selenium: {
+    start_process: true,
+    server_path: 'node_modules/selenium-server/lib/runner/selenium-server-standalone-2.53.1.jar',
+    host: '127.0.0.1',
+    port: 4444,
+    cli_args: {
       'webdriver.chrome.driver': require('chromedriver').path
     }
   },
 
-  'test_settings': {
-    'default': {
-      'selenium_port': 4444,
-      'selenium_host': 'localhost',
-      'silent': true,
-      'globals': {
-        'devServerURL': 'http://localhost:' + (process.env.PORT || config.dev.port)
+  test_settings: {
+    default: {
+      selenium_port: 4444,
+      selenium_host: 'localhost',
+      silent: true,
+      globals: {
+        devServerURL: 'http://localhost:' + (process.env.PORT || config.dev.port)
       }
     },
 
-    'chrome': {
-      'desiredCapabilities': {
-        'browserName': 'chrome',
-        'javascriptEnabled': true,
-        'acceptSslCerts': true
+    chrome: {
+      desiredCapabilities: {
+        browserName: 'chrome',
+        javascriptEnabled: true,
+        acceptSslCerts: true
       }
     },
 
-    'firefox': {
-      'desiredCapabilities': {
-        'browserName': 'firefox',
-        'javascriptEnabled': true,
-        'acceptSslCerts': true
+    firefox: {
+      desiredCapabilities: {
+        browserName: 'firefox',
+        javascriptEnabled: true,
+        acceptSslCerts: true
       }
     }
   }

--- a/template/test/unit/index.js
+++ b/template/test/unit/index.js
@@ -9,5 +9,5 @@ testsContext.keys().forEach(testsContext){{#if_eq lintConfig "airbnb"}};{{/if_eq
 // require all src files except main.js for coverage.
 // you can also change this to match only the subset of files that
 // you want coverage for.
-const srcContext = require.context('../../src', true, /^\.\/(?!main(\.js)?$)/){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+const srcContext = require.context('src', true, /^\.\/(?!main(\.js)?$)/){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 srcContext.keys().forEach(srcContext){{#if_eq lintConfig "airbnb"}};{{/if_eq}}


### PR DESCRIPTION
- Solve eslint warnings for double quotes in nightwatch config file.
- Use webpack alias `src` over relative path in unit test entry file.