### PR TITLE
Replace isparta with babel-plugin-istanbul

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,5 +1,10 @@
 {
   "presets": ["es2015", "stage-2"],
   "plugins": ["transform-runtime"],
-  "comments": false
+  "comments": false,
+  "env": {
+    "test": {
+      "plugins": [ "istanbul" ]
+    }
+  }
 }

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -40,13 +40,17 @@ module.exports = {
       {
         test: /\.vue$/,
         loader: 'eslint',
-        include: projectRoot,
+        include: [
+          path.join(projectRoot, 'src')
+        ],
         exclude: /node_modules/
       },
       {
         test: /\.js$/,
         loader: 'eslint',
-        include: projectRoot,
+        include: [
+          path.join(projectRoot, 'src')
+        ],
         exclude: /node_modules/
       }
     ],
@@ -59,7 +63,9 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel',
-        include: projectRoot,
+        include: [
+          path.join(projectRoot, 'src')
+        ],
         exclude: /node_modules/
       },
       {

--- a/template/package.json
+++ b/template/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "node build/dev-server.js",
     "build": "node build/build.js"{{#unit}},
-    "unit": "karma start test/unit/karma.conf.js --single-run"{{/unit}}{{#e2e}},
+    "unit": "cross-env BABEL_ENV=test karma start test/unit/karma.conf.js --single-run"{{/unit}}{{#e2e}},
     "e2e": "node test/e2e/runner.js"{{/e2e}}{{#if_or unit e2e}},
     "test": "{{#unit}}npm run unit{{/unit}}{{#unit}}{{#e2e}} && {{/e2e}}{{/unit}}{{#e2e}}npm run e2e{{/e2e}}"{{/if_or}}{{#lint}},
     "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs{{/e2e}}"{{/lint}}
@@ -54,6 +54,7 @@
     "http-proxy-middleware": "^0.17.2",
     "json-loader": "^0.5.4",
     {{#unit}}
+    "cross-env": "^3.1.3",
     "karma": "^1.3.0",
     "karma-coverage": "^1.1.1",
     "karma-mocha": "^1.2.0",
@@ -68,7 +69,7 @@
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
     "inject-loader": "^2.0.1",
-    "isparta-loader": "^2.0.0",
+    "babel-plugin-istanbul": "^3.0.0",
     "phantomjs-prebuilt": "^2.1.3",
     {{/unit}}
     {{#e2e}}

--- a/template/test/unit/karma.conf.js
+++ b/template/test/unit/karma.conf.js
@@ -18,7 +18,7 @@ var webpackConfig = merge(baseConfig, {
   devtool: '#inline-source-map',
   vue: {
     loaders: {
-      js: 'isparta'
+      js: 'babel-loader'
     }
   },
   plugins: [
@@ -31,18 +31,10 @@ var webpackConfig = merge(baseConfig, {
 // no need for app entry during tests
 delete webpackConfig.entry{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
-// make sure isparta loader is applied before eslint
-webpackConfig.module.preLoaders = webpackConfig.module.preLoaders || []{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-webpackConfig.module.preLoaders.unshift({
-  test: /\.js$/,
-  loader: 'isparta',
-  include: path.resolve(projectRoot, 'src'){{#if_eq lintConfig "airbnb"}},{{/if_eq}}
-}){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-
-// only apply babel for test files when using isparta
+// Use babel for test files too
 webpackConfig.module.loaders.some(function (loader, i) {
-  if (loader.loader === 'babel') {
-    loader.include = path.resolve(projectRoot, 'test/unit'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+  if (/^babel(-loader)?$/.test(loader.loader)) {
+    loader.include.push(path.resolve(projectRoot, 'test/unit')){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
     return true{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
   }
 }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}


### PR DESCRIPTION
Some attention points:

- Used arrays on the include webpack.base field because it's more flexible
- Changed the include path to the src directory
- Added `cross-env` when launching karma. `NODE_ENV=test` is necessary for coverage