### PR TITLE
FIX: can't resolve json files

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -20,7 +20,7 @@ module.exports = {
     filename: '[name].js'
   },
   resolve: {
-    extensions: ['', '.js', '.json', '.vue'],
+    extensions: ['', '.js', '.vue', '.json'],
     fallback: [path.join(__dirname, '../node_modules')],
     alias: {
       {{#if_eq build "standalone"}}

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -20,7 +20,7 @@ module.exports = {
     filename: '[name].js'
   },
   resolve: {
-    extensions: ['', '.js', '.vue'],
+    extensions: ['', '.js', '.json', '.vue'],
     fallback: [path.join(__dirname, '../node_modules')],
     alias: {
       {{#if_eq build "standalone"}}


### PR DESCRIPTION
I installed Airtable's npm package and noticed it's using implicit `require` call `require('./internal_config')` where `internal_config` is a JSON file. So when I was using this package, webpack was throwing me errors since `.json` is not a resolvable extension in the config.

I believe this could also happen when other people use other 3rd party packages so I made this patch to fix it.

The implicit require call in Airtable: (https://github.com/Airtable/airtable.js/blob/454f4b3d952ec8f717bcfce841f3937f50bddea0/lib/run_action_with_jquery.js#L4)