### PR TITLE
babel stage update

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015", "stage-2"],
+  "presets": ["es2015", "stage-1"],
   "plugins": ["transform-runtime"],
   "comments": false
 }

--- a/template/package.json
+++ b/template/package.json
@@ -24,7 +24,7 @@
     "babel-loader": "^6.0.0",
     "babel-plugin-transform-runtime": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",
-    "babel-preset-stage-2": "^6.0.0",
+    "babel-preset-stage-1": "^6.0.0",
     "babel-register": "^6.0.0",
     "chalk": "^1.1.3",
     "connect-history-api-fallback": "^1.1.0",


### PR DESCRIPTION
Update babel stage-2 to stage 1 which includes the import/export syntax
`export * as name from 'module';`. Which is useful for writing index.js files that you want batch import and then export.