### PR TITLE
FIX: JSON.stringify env object

### DIFF
--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -19,7 +19,7 @@ module.exports = merge(baseWebpackConfig, {
   devtool: '#eval-source-map',
   plugins: [
     new webpack.DefinePlugin({
-      'process.env': config.dev.env
+      'process.env': JSON.stringify(config.dev.env)
     }),
     // https://github.com/glenjamin/webpack-hot-middleware#installation--usage
     new webpack.optimize.OccurrenceOrderPlugin(),

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -29,7 +29,7 @@ var webpackConfig = merge(baseWebpackConfig, {
   plugins: [
     // http://vuejs.github.io/vue-loader/en/workflow/production.html
     new webpack.DefinePlugin({
-      'process.env': env
+      'process.env': JSON.stringify(env)
     }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {

--- a/template/config/dev.env.js
+++ b/template/config/dev.env.js
@@ -2,5 +2,5 @@ var merge = require('webpack-merge')
 var prodEnv = require('./prod.env')
 
 module.exports = merge(prodEnv, {
-  NODE_ENV: '"development"'
+  NODE_ENV: "development"
 })

--- a/template/config/prod.env.js
+++ b/template/config/prod.env.js
@@ -1,3 +1,3 @@
 module.exports = {
-  NODE_ENV: '"production"'
+  NODE_ENV: "production"
 }

--- a/template/config/test.env.js
+++ b/template/config/test.env.js
@@ -2,5 +2,5 @@ var merge = require('webpack-merge')
 var devEnv = require('./dev.env')
 
 module.exports = merge(devEnv, {
-  NODE_ENV: '"testing"'
+  NODE_ENV: "testing"
 })


### PR DESCRIPTION
I recently need to define an object in  `config/env.dev.js` like this:

```
module.exports = merge(prodEnv, {
  NODE_ENV: '"development"',
  GLOBAL_VAR1: {
    PROP1: "someValue"
  }
})
```

when I was trying to load to "someValue" into my code with `process.env.GLOBAL_VAR1.PROP1`, I got `ReferenceError` for `someValue`.

Adding `JSON.stringify` solved my problem.