### PR TITLE
Add friendly-errors-webpack-plugin

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -21,13 +21,12 @@ var compiler = webpack(webpackConfig)
 
 var devMiddleware = require('webpack-dev-middleware')(compiler, {
   publicPath: webpackConfig.output.publicPath,
-  stats: {
-    colors: true,
-    chunks: false
-  }
+  quiet: true
 })
 
-var hotMiddleware = require('webpack-hot-middleware')(compiler)
+var hotMiddleware = require('webpack-hot-middleware')(compiler, {
+  log: () => {}
+})
 // force page reload when html-webpack-plugin template changes
 compiler.plugin('compilation', function (compilation) {
   compilation.plugin('html-webpack-plugin-after-emit', function (data, cb) {

--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -58,13 +58,17 @@ app.use(hotMiddleware)
 var staticPath = path.posix.join(config.dev.assetsPublicPath, config.dev.assetsSubDirectory)
 app.use(staticPath, express.static('./static'))
 
+var uri = 'http://localhost:' + port
+
+devMiddleware.waitUntilValid(function () {
+  console.log('> Listening at ' + uri + '\n')
+})
+
 module.exports = app.listen(port, function (err) {
   if (err) {
     console.log(err)
     return
   }
-  var uri = 'http://localhost:' + port
-  console.log('Listening at ' + uri + '\n')
 
   // when env is testing, don't need open it
   if (process.env.NODE_ENV !== 'testing') {

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -4,6 +4,7 @@ var merge = require('webpack-merge')
 var utils = require('./utils')
 var baseWebpackConfig = require('./webpack.base.conf')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
+var FriendlyErrors = require('friendly-errors-webpack-plugin')
 
 // add hot-reload related code to entry chunks
 Object.keys(baseWebpackConfig.entry).forEach(function (name) {
@@ -29,6 +30,7 @@ module.exports = merge(baseWebpackConfig, {
       filename: 'index.html',
       template: 'index.html',
       inject: true
-    })
+    }),
+    new FriendlyErrors()
   ]
 })

--- a/template/package.json
+++ b/template/package.json
@@ -49,6 +49,7 @@
     "express": "^4.13.3",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
+    "friendly-errors-webpack-plugin": "^1.1.2",
     "function-bind": "^1.0.2",
     "html-webpack-plugin": "^2.8.1",
     "http-proxy-middleware": "^0.17.2",


### PR DESCRIPTION
This plugin provides more readable error log. For example, it's very confusing to have both eslint error log and syntax error log in the console.

![2016-12-29 5 42 59](https://cloud.githubusercontent.com/assets/8784712/21541104/f0a1da34-cdee-11e6-9d4f-27dbdd5fc7ab.png)

![2016-12-29 5 43 21](https://cloud.githubusercontent.com/assets/8784712/21541106/f4c7cd44-cdee-11e6-849d-bbc8d7b8d005.png)
