### PR TITLE
add geckodriver for running e2e tests in firefox

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -75,6 +75,7 @@
     {{/unit}}
     {{#e2e}}
     "chromedriver": "^2.21.2",
+    "geckodriver": "^1.2.0",
     "cross-spawn": "^4.0.2",
     "nightwatch": "^0.9.8",
     "selenium-server": "2.53.1",

--- a/template/package.json
+++ b/template/package.json
@@ -75,7 +75,7 @@
     {{/unit}}
     {{#e2e}}
     "chromedriver": "^2.21.2",
-    "geckodriver": "^1.2.0",
+    "geckodriver": "^1.3.0",
     "cross-spawn": "^4.0.2",
     "nightwatch": "^0.9.8",
     "selenium-server": "2.53.1",

--- a/template/test/e2e/nightwatch.conf.js
+++ b/template/test/e2e/nightwatch.conf.js
@@ -13,7 +13,8 @@ module.exports = {
     host: '127.0.0.1',
     port: 4444,
     cli_args: {
-      'webdriver.chrome.driver': require('chromedriver').path
+      'webdriver.chrome.driver': require('chromedriver').path,
+      'webdriver.gecko.driver': require('geckodriver').path
     }
   },
 
@@ -38,6 +39,7 @@ module.exports = {
     firefox: {
       desiredCapabilities: {
         browserName: 'firefox',
+        marionette: true,
         javascriptEnabled: true,
         acceptSslCerts: true
       }

--- a/template/test/e2e/runner.js
+++ b/template/test/e2e/runner.js
@@ -14,7 +14,7 @@ if (opts.indexOf('--config') === -1) {
   opts = opts.concat(['--config', 'test/e2e/nightwatch.conf.js']){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 }
 if (opts.indexOf('--env') === -1) {
-  opts = opts.concat(['--env', 'chrome']){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+  opts = opts.concat(['--env', 'chrome,firefox']){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 }
 
 var spawn = require('cross-spawn'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/test/e2e/runner.js
+++ b/template/test/e2e/runner.js
@@ -14,7 +14,7 @@ if (opts.indexOf('--config') === -1) {
   opts = opts.concat(['--config', 'test/e2e/nightwatch.conf.js']){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 }
 if (opts.indexOf('--env') === -1) {
-  opts = opts.concat(['--env', 'chrome,firefox']){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+  opts = opts.concat(['--env', 'chrome']){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 }
 
 var spawn = require('cross-spawn'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}


### PR DESCRIPTION
The npm package is a wrap for [geckodriver binaries](https://github.com/mozilla/geckodriver/releases), very similar to chromedriver.