### PR TITLE
Introduce bundle analyzer plugin in production build

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -13,6 +13,9 @@ npm run dev
 
 # build for production with minification
 npm run build
+
+# build for production and view the bundle analyzer report
+npm run build --report
 {{#unit}}
 
 # run unit tests

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -99,4 +99,9 @@ if (config.build.productionGzip) {
   )
 }
 
+if (config.build.bundleAnalyzerReport) {
+  var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
+  webpackConfig.plugins.push(new BundleAnalyzerPlugin())
+}
+
 module.exports = webpackConfig

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -14,7 +14,12 @@ module.exports = {
     // Before setting to `true`, make sure to:
     // npm install --save-dev compression-webpack-plugin
     productionGzip: false,
-    productionGzipExtensions: ['js', 'css']
+    productionGzipExtensions: ['js', 'css'],
+    // Run the build command with an extra argument to
+    // View the bundle analyzer report after build finishes:
+    // `npm run build --report`
+    // Set to `true` or `false` to always turn it on or off
+    bundleAnalyzerReport: process.env.npm_config_report
   },
   dev: {
     env: require('./dev.env'),

--- a/template/package.json
+++ b/template/package.json
@@ -54,6 +54,7 @@
     "html-webpack-plugin": "^2.8.1",
     "http-proxy-middleware": "^0.17.2",
     "json-loader": "^0.5.4",
+    "webpack-bundle-analyzer": "^2.2.1",
     {{#unit}}
     "cross-env": "^3.1.3",
     "karma": "^1.3.0",


### PR DESCRIPTION
In regard to production optimization, sometimes we may wonder is it possible to reduce my bundle size? What library contributes the most? For such cases, a bundle analyzer report is very helpful. See [npm](https://www.npmjs.com/package/webpack-bundle-analyzer) for more about the plugin.