### PR TITLE
Use #cheap-module-eval-source-map for development

### DIFF
--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -15,8 +15,8 @@ module.exports = merge(baseWebpackConfig, {
   module: {
     loaders: utils.styleLoaders({ sourceMap: config.dev.cssSourceMap })
   },
-  // eval-source-map is faster for development
-  devtool: '#eval-source-map',
+  // cheap-module-eval-source-map is faster for development
+  devtool: '#cheap-module-eval-source-map',
   plugins: [
     new webpack.DefinePlugin({
       'process.env': config.dev.env


### PR DESCRIPTION
The build speed of `cheap-module-eval-source-map` is faster than just `eval-source-map`, and it works very well in most scenarios.

Thus I'd recommend to use cheap-module-eval-source-map for development.

webpack docs: https://webpack.github.io/docs/configuration.html#devtool