### PR TITLE
Migration to webpack 2

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,5 +1,8 @@
 {
-  "presets": ["es2015", "stage-2"],
+  "presets": [
+    [ "es2015", { "modules": false } ],
+    "stage-2"
+  ],
   "plugins": ["transform-runtime"],
   "comments": false,
   "env": {

--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -48,6 +48,35 @@ exports.cssLoaders = function (options) {
   }
 }
 
+// return stringified loaders
+exports.vueCSSLoaders = function (options) {
+  var output = {}
+  var loaders = exports.cssLoaders(options)
+
+  for (var extension in loaders) {
+    if (typeof loaders[extension] === "string") {
+      output[extension] = loaders[extension]
+    } else {
+      loader = loaders[extension].map(function(l) {
+        var loaderName = l.loader;
+        var loaderOptions = l.options || {};
+
+        if (Object.keys(loaderOptions).lenght === 0) {
+          return loaderName;
+        }
+
+        return loaderName + '?' + Object.keys(loaderOptions).map(function(key) {
+          return key + '=' + loaderOptions[key]
+        }).join('&')
+      }).join('!')
+
+      output[extension] = loader
+    }
+  }
+
+  return output
+}
+
 // Generate loaders for standalone style files (outside of .vue)
 exports.styleLoaders = function (options) {
   var output = []

--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -28,7 +28,7 @@ exports.cssLoaders = function (options) {
     // Extract CSS when that option is specified
     // (which is the case during production build)
     if (options.extract) {
-      return ExtractTextPlugin.extract('vue-style-loader', sourceLoader)
+      return ExtractTextPlugin.extract({ fallbackLoader: 'vue-style-loader', loader: sourceLoader })
     } else {
       return ['vue-style-loader', sourceLoader].join('!')
     }

--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -12,37 +12,39 @@ exports.assetsPath = function (_path) {
 exports.cssLoaders = function (options) {
   options = options || {}
   // generate loader string to be used with extract text plugin
-  function generateLoaders (loaders) {
-    var sourceLoader = loaders.map(function (loader) {
-      var extraParamChar
-      if (/\?/.test(loader)) {
-        loader = loader.replace(/\?/, '-loader?')
-        extraParamChar = '&'
-      } else {
-        loader = loader + '-loader'
-        extraParamChar = '?'
-      }
-      return loader + (options.sourceMap ? extraParamChar + 'sourceMap' : '')
-    }).join('!')
+  function generateCSSLoader (loader, loaderOptions) {
+    loaders = [{
+        loader: 'css-loader',
+        options: Object.assign({}, options),
+    }]
+
+    if (loader) {
+      loaders.push({
+        loader: loader + '-loader',
+        options: Object.assign({}, options, loaderOptions),
+      })
+    }
 
     // Extract CSS when that option is specified
     // (which is the case during production build)
     if (options.extract) {
-      return ExtractTextPlugin.extract({ fallbackLoader: 'vue-style-loader', loader: sourceLoader })
+      return ExtractTextPlugin.extract({ fallbackLoader: 'vue-style-loader', loader: loaders })
     } else {
-      return ['vue-style-loader', sourceLoader].join('!')
+      return [{
+        loader: 'vue-style-loader'
+      }].concat(loaders)
     }
   }
 
   // http://vuejs.github.io/vue-loader/en/configurations/extract-css.html
   return {
-    css: generateLoaders(['css']),
-    postcss: generateLoaders(['css']),
-    less: generateLoaders(['css', 'less']),
-    sass: generateLoaders(['css', 'sass?indentedSyntax']),
-    scss: generateLoaders(['css', 'sass']),
-    stylus: generateLoaders(['css', 'stylus']),
-    styl: generateLoaders(['css', 'stylus'])
+    css: generateCSSLoader(),
+    postcss: generateCSSLoader(),
+    less: generateCSSLoader('less'),
+    sass: generateCSSLoader('sass', {indentedSyntax: true}),
+    scss: generateCSSLoader('sass'),
+    stylus: generateCSSLoader('stylus'),
+    styl: generateCSSLoader('stylus')
   }
 }
 
@@ -51,10 +53,9 @@ exports.styleLoaders = function (options) {
   var output = []
   var loaders = exports.cssLoaders(options)
   for (var extension in loaders) {
-    var loader = loaders[extension]
     output.push({
       test: new RegExp('\\.' + extension + '$'),
-      loader: loader
+      use: loaders[extension]
     })
   }
   return output

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -32,7 +32,7 @@ module.exports = {
     }
   },
   module: {
-    loaders: [
+    rules: [
     {{#lint}}
       {
         test: /\.vue$/,

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -72,7 +72,7 @@ module.exports = {
       {
         test: /\.(png|jpe?g|gif|svg)(\?.*)?$/,
         loader: 'url-loader',
-        query: {
+        options: {
           limit: 10000,
           name: utils.assetsPath('img/[name].[hash:7].[ext]')
         }
@@ -80,7 +80,7 @@ module.exports = {
       {
         test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
         loader: 'url-loader',
-        query: {
+        options: {
           limit: 10000,
           name: utils.assetsPath('fonts/[name].[hash:7].[ext]')
         }

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -83,7 +83,7 @@ module.exports = {
         eslint: {
           formatter: require('eslint-friendly-formatter')
         },
-
+        context: ''
       }
     })
   {{/lint}}]

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -55,7 +55,15 @@ module.exports = {
     {{/lint}}
       {
         test: /\.vue$/,
-        loader: 'vue-loader'
+        loader: 'vue-loader',
+          options: {
+          loaders: utils.vueCSSLoaders({ sourceMap: useCssSourceMap }),
+          postcss: [
+            require('autoprefixer')({
+              browsers: ['last 2 versions']
+            })
+          ]
+        }
       },
       {
         test: /\.js$/,
@@ -90,14 +98,6 @@ module.exports = {
         formatter: require('eslint-friendly-formatter')
       },
       {{/lint}}
-      vue: {
-        loaders: utils.vueCSSLoaders({ sourceMap: useCssSourceMap }),
-        postcss: [
-          require('autoprefixer')({
-            browsers: ['last 2 versions']
-          })
-        ]
-      }
     }
   })]
 }

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -99,5 +99,5 @@ module.exports = {
         ]
       }
     }
-  ]
+  })]
 }

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -1,4 +1,5 @@
 var path = require('path')
+var webpack = require('webpack')
 var config = require('../config')
 var utils = require('./utils')
 var projectRoot = path.resolve(__dirname, '../')
@@ -20,8 +21,7 @@ module.exports = {
     filename: '[name].js'
   },
   resolve: {
-    extensions: ['', '.js', '.vue', '.json'],
-    fallback: [path.join(__dirname, '../node_modules')],
+    extensions: ['.js', '.vue', '.json'],
     alias: {
       {{#if_eq build "standalone"}}
       'vue$': 'vue/dist/vue.common.js',
@@ -31,38 +31,35 @@ module.exports = {
       'components': path.resolve(__dirname, '../src/components')
     }
   },
-  resolveLoader: {
-    fallback: [path.join(__dirname, '../node_modules')]
-  },
   module: {
-    {{#lint}}
-    preLoaders: [
-      {
-        test: /\.vue$/,
-        loader: 'eslint',
-        include: [
-          path.join(projectRoot, 'src')
-        ],
-        exclude: /node_modules/
-      },
-      {
-        test: /\.js$/,
-        loader: 'eslint',
-        include: [
-          path.join(projectRoot, 'src')
-        ],
-        exclude: /node_modules/
-      }
-    ],
-    {{/lint}}
     loaders: [
+    {{#lint}}
       {
         test: /\.vue$/,
-        loader: 'vue'
+        loader: 'eslint-loader',
+        enforce: 'pre',
+        include: [
+          path.join(projectRoot, 'src')
+        ],
+        exclude: /node_modules/
       },
       {
         test: /\.js$/,
-        loader: 'babel',
+        loader: 'eslint-loader',
+        enforce: 'pre',
+        include: [
+          path.join(projectRoot, 'src')
+        ],
+        exclude: /node_modules/
+      },
+    {{/lint}}
+      {
+        test: /\.vue$/,
+        loader: 'vue-loader'
+      },
+      {
+        test: /\.js$/,
+        loader: 'babel-loader',
         include: [
           path.join(projectRoot, 'src')
         ],
@@ -70,11 +67,11 @@ module.exports = {
       },
       {
         test: /\.json$/,
-        loader: 'json'
+        loader: 'json-loader'
       },
       {
         test: /\.(png|jpe?g|gif|svg)(\?.*)?$/,
-        loader: 'url',
+        loader: 'url-loader',
         query: {
           limit: 10000,
           name: utils.assetsPath('img/[name].[hash:7].[ext]')
@@ -82,7 +79,7 @@ module.exports = {
       },
       {
         test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
-        loader: 'url',
+        loader: 'url-loader',
         query: {
           limit: 10000,
           name: utils.assetsPath('fonts/[name].[hash:7].[ext]')
@@ -90,17 +87,21 @@ module.exports = {
       }
     ]
   },
-  {{#lint}}
-  eslint: {
-    formatter: require('eslint-friendly-formatter')
-  },
-  {{/lint}}
-  vue: {
-    loaders: utils.cssLoaders({ sourceMap: useCssSourceMap }),
-    postcss: [
-      require('autoprefixer')({
-        browsers: ['last 2 versions']
-      })
-    ]
-  }
+  plugins: [new webpack.LoaderOptionsPlugin({
+    options: {
+      {{#lint}}
+      eslint: {
+        formatter: require('eslint-friendly-formatter')
+      },
+      {{/lint}}
+      vue: {
+        loaders: utils.cssLoaders({ sourceMap: useCssSourceMap }),
+        postcss: [
+          require('autoprefixer')({
+            browsers: ['last 2 versions']
+          })
+        ]
+      }
+    }
+  ]
 }

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -91,7 +91,7 @@ module.exports = {
       },
       {{/lint}}
       vue: {
-        loaders: utils.cssLoaders({ sourceMap: useCssSourceMap }),
+        loaders: utils.vueCSSLoaders({ sourceMap: useCssSourceMap }),
         postcss: [
           require('autoprefixer')({
             browsers: ['last 2 versions']

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -5,11 +5,7 @@ var utils = require('./utils')
 var projectRoot = path.resolve(__dirname, '../')
 
 var env = process.env.NODE_ENV
-// check env & config/index.js to decide whether to enable CSS source maps for the
-// various preprocessor loaders added to vue-loader at the end of this file
-var cssSourceMapDev = (env === 'development' && config.dev.cssSourceMap)
-var cssSourceMapProd = (env === 'production' && config.build.productionSourceMap)
-var useCssSourceMap = cssSourceMapDev || cssSourceMapProd
+
 
 module.exports = {
   entry: {
@@ -53,18 +49,6 @@ module.exports = {
         exclude: /node_modules/
       },
     {{/lint}}
-      {
-        test: /\.vue$/,
-        loader: 'vue-loader',
-          options: {
-          loaders: utils.vueCSSLoaders({ sourceMap: useCssSourceMap }),
-          postcss: [
-            require('autoprefixer')({
-              browsers: ['last 2 versions']
-            })
-          ]
-        }
-      },
       {
         test: /\.js$/,
         loader: 'babel-loader',

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -91,13 +91,16 @@ module.exports = {
       }
     ]
   },
-  plugins: [new webpack.LoaderOptionsPlugin({
-    options: {
-      {{#lint}}
-      eslint: {
-        formatter: require('eslint-friendly-formatter')
-      },
-      {{/lint}}
-    }
-  })]
+  plugins: [{{#lint}}
+    // this leaves here since eslint loader doesn't yet support webpack 2
+    // way to pass options.
+    new webpack.LoaderOptionsPlugin({
+      options: {
+        eslint: {
+          formatter: require('eslint-friendly-formatter')
+        },
+
+      }
+    })
+  {{/lint}}]
 }

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -66,10 +66,6 @@ module.exports = {
         exclude: /node_modules/
       },
       {
-        test: /\.json$/,
-        loader: 'json-loader'
-      },
-      {
         test: /\.(png|jpe?g|gif|svg)(\?.*)?$/,
         loader: 'url-loader',
         options: {

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -13,7 +13,7 @@ Object.keys(baseWebpackConfig.entry).forEach(function (name) {
 
 module.exports = merge(baseWebpackConfig, {
   module: {
-    loaders: utils.styleLoaders({ sourceMap: config.dev.cssSourceMap })
+    rules: utils.styleLoaders({ sourceMap: config.dev.cssSourceMap })
   },
   // eval-source-map is faster for development
   devtool: '#eval-source-map',

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -6,7 +6,6 @@ var baseWebpackConfig = require('./webpack.base.conf')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 var FriendlyErrors = require('friendly-errors-webpack-plugin')
 
-var useCssSourceMap = (env === 'development' && config.dev.cssSourceMap)
 
 // add hot-reload related code to entry chunks
 Object.keys(baseWebpackConfig.entry).forEach(function (name) {
@@ -19,7 +18,7 @@ module.exports = merge(baseWebpackConfig, {
         test: /\.vue$/,
         loader: 'vue-loader',
           options: {
-          loaders: utils.vueCSSLoaders({ sourceMap: useCssSourceMap }),
+          loaders: utils.vueCSSLoaders({ sourceMap: config.dev.cssSourceMap }),
           postcss: [
             require('autoprefixer')({
               browsers: ['last 2 versions']

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -6,6 +6,8 @@ var baseWebpackConfig = require('./webpack.base.conf')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 var FriendlyErrors = require('friendly-errors-webpack-plugin')
 
+var useCssSourceMap = (env === 'development' && config.dev.cssSourceMap)
+
 // add hot-reload related code to entry chunks
 Object.keys(baseWebpackConfig.entry).forEach(function (name) {
   baseWebpackConfig.entry[name] = ['./build/dev-client'].concat(baseWebpackConfig.entry[name])
@@ -13,7 +15,18 @@ Object.keys(baseWebpackConfig.entry).forEach(function (name) {
 
 module.exports = merge(baseWebpackConfig, {
   module: {
-    rules: utils.styleLoaders({ sourceMap: config.dev.cssSourceMap })
+    rules: utils.styleLoaders({ sourceMap: config.dev.cssSourceMap }).concat([{
+        test: /\.vue$/,
+        loader: 'vue-loader',
+          options: {
+          loaders: utils.vueCSSLoaders({ sourceMap: useCssSourceMap }),
+          postcss: [
+            require('autoprefixer')({
+              browsers: ['last 2 versions']
+            })
+          ]
+        }
+      }])
   },
   // eval-source-map is faster for development
   devtool: '#eval-source-map',

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -22,9 +22,8 @@ module.exports = merge(baseWebpackConfig, {
       'process.env': config.dev.env
     }),
     // https://github.com/glenjamin/webpack-hot-middleware#installation--usage
-    new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin(),
+    new webpack.NoEmitOnErrorsPlugin(),
     // https://github.com/ampedandwired/html-webpack-plugin
     new HtmlWebpackPlugin({
       filename: 'index.html',

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -23,7 +23,7 @@ var webpackConfig = merge(baseWebpackConfig, {
   plugins: [
     new webpack.LoaderOptionsPlugin({
       vue: {
-        loaders: utils.cssLoaders({
+        loaders: utils.vueCSSLoaders({
           sourceMap: config.build.productionSourceMap,
           extract: true
         })

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -21,7 +21,7 @@ var webpackConfig = merge(baseWebpackConfig, {
     chunkFilename: utils.assetsPath('js/[id].[chunkhash].js')
   },
   plugins: [
-    plugins: [new webpack.LoaderOptionsPlugin({
+    new webpack.LoaderOptionsPlugin({
       vue: {
         loaders: utils.cssLoaders({
           sourceMap: config.build.productionSourceMap,

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -28,7 +28,7 @@ var webpackConfig = merge(baseWebpackConfig, {
           extract: true
         })
       }
-    },
+    }),
     // http://vuejs.github.io/vue-loader/en/workflow/production.html
     new webpack.DefinePlugin({
       'process.env': env

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -12,7 +12,7 @@ var env = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'
 
 var webpackConfig = merge(baseWebpackConfig, {
   module: {
-    loaders: utils.styleLoaders({ sourceMap: config.build.productionSourceMap, extract: true })
+    rules: utils.styleLoaders({ sourceMap: config.build.productionSourceMap, extract: true })
   },
   devtool: config.build.productionSourceMap ? '#source-map' : false,
   output: {

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -10,6 +10,7 @@ var env = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'
   ? require('../config/test.env')
   : {{/if_or}}config.build.env
 
+
 var webpackConfig = merge(baseWebpackConfig, {
   module: {
     rules: utils.styleLoaders({ sourceMap: config.build.productionSourceMap, extract: true }).concat([{

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -12,7 +12,16 @@ var env = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'
 
 var webpackConfig = merge(baseWebpackConfig, {
   module: {
-    rules: utils.styleLoaders({ sourceMap: config.build.productionSourceMap, extract: true })
+    rules: utils.styleLoaders({ sourceMap: config.build.productionSourceMap, extract: true }).concat([{
+      test: /\.vue$/,
+      loader: 'vue-loader',
+        options: {
+          loaders: utils.vueCSSLoaders({
+            sourceMap: config.build.productionSourceMap,
+            extract: true
+          })
+        }
+    }])
   },
   devtool: config.build.productionSourceMap ? '#source-map' : false,
   output: {
@@ -21,14 +30,6 @@ var webpackConfig = merge(baseWebpackConfig, {
     chunkFilename: utils.assetsPath('js/[id].[chunkhash].js')
   },
   plugins: [
-    new webpack.LoaderOptionsPlugin({
-      vue: {
-        loaders: utils.vueCSSLoaders({
-          sourceMap: config.build.productionSourceMap,
-          extract: true
-        })
-      }
-    }),
     // http://vuejs.github.io/vue-loader/en/workflow/production.html
     new webpack.DefinePlugin({
       'process.env': env

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -20,13 +20,15 @@ var webpackConfig = merge(baseWebpackConfig, {
     filename: utils.assetsPath('js/[name].[chunkhash].js'),
     chunkFilename: utils.assetsPath('js/[id].[chunkhash].js')
   },
-  vue: {
-    loaders: utils.cssLoaders({
-      sourceMap: config.build.productionSourceMap,
-      extract: true
-    })
-  },
   plugins: [
+    plugins: [new webpack.LoaderOptionsPlugin({
+      vue: {
+        loaders: utils.cssLoaders({
+          sourceMap: config.build.productionSourceMap,
+          extract: true
+        })
+      }
+    },
     // http://vuejs.github.io/vue-loader/en/workflow/production.html
     new webpack.DefinePlugin({
       'process.env': env

--- a/template/package.json
+++ b/template/package.json
@@ -62,7 +62,7 @@
     "karma-sinon-chai": "^1.2.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.26",
-    "karma-webpack": "^2.2.0",
+    "karma-webpack": "^2.0.2",
     "lolex": "^1.4.0",
     "mocha": "^3.1.0",
     "chai": "^3.5.0",

--- a/template/package.json
+++ b/template/package.json
@@ -47,7 +47,7 @@
     {{/lint}}
     "eventsource-polyfill": "^0.9.6",
     "express": "^4.13.3",
-    "extract-text-webpack-plugin": "^1.0.1",
+    "extract-text-webpack-plugin": "^2.0.0-beta.5",
     "file-loader": "^0.9.0",
     "friendly-errors-webpack-plugin": "^1.1.2",
     "function-bind": "^1.0.2",
@@ -87,10 +87,10 @@
     "vue-loader": "^10.0.0",
     "vue-style-loader": "^1.0.0",
     "vue-template-compiler": "^2.1.0",
-    "webpack": "^1.13.2",
-    "webpack-dev-middleware": "^1.8.3",
-    "webpack-hot-middleware": "^2.12.2",
-    "webpack-merge": "^0.14.1"
+    "webpack": "^2.2.0",
+    "webpack-dev-middleware": "^1.9.0",
+    "webpack-hot-middleware": "^2.15.0",
+    "webpack-merge": "^2.4.0"
   },
   "engines": {
     "node": ">= 4.0.0",

--- a/template/package.json
+++ b/template/package.json
@@ -47,7 +47,7 @@
     {{/lint}}
     "eventsource-polyfill": "^0.9.6",
     "express": "^4.13.3",
-    "extract-text-webpack-plugin": "^2.0.0-beta.5",
+    "extract-text-webpack-plugin": "^2.0.0-rc.0",
     "file-loader": "^0.9.0",
     "friendly-errors-webpack-plugin": "^1.1.2",
     "function-bind": "^1.0.2",

--- a/template/package.json
+++ b/template/package.json
@@ -28,21 +28,21 @@
     "babel-register": "^6.0.0",
     "chalk": "^1.1.3",
     "connect-history-api-fallback": "^1.1.0",
-    "css-loader": "^0.25.0",
+    "css-loader": "^0.26.1",
     {{#lint}}
     "eslint": "^3.7.1",
     "eslint-friendly-formatter": "^2.0.5",
     "eslint-loader": "^1.5.0",
-    "eslint-plugin-html": "^1.3.0",
+    "eslint-plugin-html": "^2.0.0",
     {{#if_eq lintConfig "standard"}}
     "eslint-config-standard": "^6.1.0",
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "^2.0.1",
     {{/if_eq}}
     {{#if_eq lintConfig "airbnb"}}
-    "eslint-config-airbnb-base": "^8.0.0",
+    "eslint-config-airbnb-base": "11.0.1",
     "eslint-import-resolver-webpack": "^0.8.1",
-    "eslint-plugin-import": "^1.16.0",
+    "eslint-plugin-import": "^2.2.0",
     {{/if_eq}}
     {{/lint}}
     "eventsource-polyfill": "^0.9.6",
@@ -62,7 +62,7 @@
     "karma-sinon-chai": "^1.2.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.26",
-    "karma-webpack": "^1.7.0",
+    "karma-webpack": "^2.2.0",
     "lolex": "^1.4.0",
     "mocha": "^3.1.0",
     "chai": "^3.5.0",
@@ -76,7 +76,7 @@
     "chromedriver": "^2.21.2",
     "cross-spawn": "^4.0.2",
     "nightwatch": "^0.9.8",
-    "selenium-server": "2.53.1",
+    "selenium-server": "3.0.1",
     {{/e2e}}
     "semver": "^5.3.0",
     "opn": "^4.0.2",

--- a/template/package.json
+++ b/template/package.json
@@ -41,7 +41,7 @@
     {{/if_eq}}
     {{#if_eq lintConfig "airbnb"}}
     "eslint-config-airbnb-base": "^8.0.0",
-    "eslint-import-resolver-webpack": "^0.6.0",
+    "eslint-import-resolver-webpack": "^0.8.1",
     "eslint-plugin-import": "^1.16.0",
     {{/if_eq}}
     {{/lint}}

--- a/template/package.json
+++ b/template/package.json
@@ -53,7 +53,6 @@
     "function-bind": "^1.0.2",
     "html-webpack-plugin": "^2.8.1",
     "http-proxy-middleware": "^0.17.2",
-    "json-loader": "^0.5.4",
     {{#unit}}
     "cross-env": "^3.1.3",
     "karma": "^1.3.0",

--- a/template/test/e2e/nightwatch.conf.js
+++ b/template/test/e2e/nightwatch.conf.js
@@ -9,7 +9,7 @@ module.exports = {
 
   selenium: {
     start_process: true,
-    server_path: 'node_modules/selenium-server/lib/runner/selenium-server-standalone-2.53.1.jar',
+    server_path: 'node_modules/selenium-server/lib/runner/selenium-server-standalone-3.0.1.jar',
     host: '127.0.0.1',
     port: 4444,
     cli_args: {

--- a/template/test/unit/karma.conf.js
+++ b/template/test/unit/karma.conf.js
@@ -13,14 +13,17 @@ var projectRoot = path.resolve(__dirname, '../../'){{#if_eq lintConfig "airbnb"}
 var webpackConfig = merge(baseConfig, {
   // use inline sourcemap for karma-sourcemap-loader
   module: {
-    loaders: utils.styleLoaders()
+    rules: utils.styleLoaders().concat([{
+      test: /\.vue$/,
+      loader: 'vue-loader',
+      options: {
+        loaders: {
+          js: 'babel-loader',
+        },
+      },
+    }]),
   },
   devtool: '#inline-source-map',
-  vue: {
-    loaders: {
-      js: 'babel-loader'
-    }
-  },
   plugins: [
     new webpack.DefinePlugin({
       'process.env': require('../../config/test.env')
@@ -32,7 +35,7 @@ var webpackConfig = merge(baseConfig, {
 delete webpackConfig.entry{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 // Use babel for test files too
-webpackConfig.module.loaders.some(function (loader, i) {
+webpackConfig.module.rules.some(function (loader, i) {
   if (/^babel(-loader)?$/.test(loader.loader)) {
     loader.include.push(path.resolve(projectRoot, 'test/unit')){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
     return true{{#if_eq lintConfig "airbnb"}};{{/if_eq}}


### PR DESCRIPTION
See #454

- [x] refactor resolve.root, resolve.fallback, resolve.modulesDirectories to `resolve.modules
- [x] ditto for resolveLoader
- [x]  remove empty string in resolve.extensions
- [x] rename module.loaders to module.rules
- [x] rename all loaders to their long names (babel -> babel-loader )
- [x] switch loader chains to use: [...]
- [x] remove json loader (active by default)
- [x] refactor pre-Loaders into loaders.
- [x] remove OccurrenceOrderPlugin (active by default now)
- [x] css utility function for vue-loader options have to be refactored to work with webpack 2 new rules option syntax.
- [ ] Add sourcemap: true to UglifyJSPlugin in prod config, remove warnings (auto false now)
- [x] update ExtractTextPlugin (also adjust syntax)
- [x] update webpack-dev-middleware
- [x] add modules: false in .babelrc to let webpack handle ES6 modules syntax