### PR TITLE
Is exclude really necessary?

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -50,8 +50,7 @@ module.exports = {
         loader: 'eslint',
         include: [
           path.join(projectRoot, 'src')
-        ],
-        exclude: /node_modules/
+        ]
       }
     ],
     {{/lint}}


### PR DESCRIPTION
I mean, it’s hindering proper import of .vue components.