### PR TITLE
Support filter option for full control over path matching

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -41,7 +41,7 @@ Object.keys(proxyTable).forEach(function (context) {
   if (typeof options === 'string') {
     options = { target: options }
   }
-  app.use(proxyMiddleware(context, options))
+  app.use(proxyMiddleware(options.filter || context, options))
 })
 
 // handle fallback for HTML5 history API


### PR DESCRIPTION
https://github.com/chimurai/http-proxy-middleware#http-proxy-middleware-options

<blockquote>
custom matching

For full control you can provide a custom function to determine which requests should be proxied or not.

```
/**
 * @return {Boolean}
 */
var filter = function (pathname, req) {
    return (pathname.match('^/api') && req.method === 'GET');
};

var apiProxy = proxy(filter, {target: 'http://www.example.org'})
```
</blockquote>

With this small change, it is possible to pass a `filter` property in a proxy table entry to use a request filter function instead of using the proxy table key as the context. The context is ignored. For example:

```
proxyTable: {
  '/': { // The root page is rendered the backend
    target: 'http://localhost:6543',
    filter: (pathname, req) => {
      return pathname === '/'; // Only proxy the root path, bypass for other build artifacts
    }
  },
  '/api': {
    target: 'http://localhost:6543'
  },
  ...
```