### PR TITLE
Move import at the top to prevent eslint error

### DIFF
--- a/template/src/router/index.js
+++ b/template/src/router/index.js
@@ -1,9 +1,8 @@
 import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 import Router from 'vue-router'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import Hello from 'components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 Vue.use(Router){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-
-import Hello from 'components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 export default new Router({
   routes: [


### PR DESCRIPTION
By doing this it fixes the following error

```
 ERROR  Failed to compile with 1 errors

 error  in ./src/router/index.js


  ✘  https://google.com/#q=import%2Ffirst  Import in body of module; reorder to top
  /Users/asumaran/www/my-project/src/router/index.js:6:1
  import Hello from 'components/Hello';
   ^


✘ 1 problem (1 error, 0 warnings)
```