### PR TITLE
update ExtractTextPlugin config to version 2 options

### DIFF
--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -29,8 +29,8 @@ exports.cssLoaders = function (options) {
     // (which is the case during production build)
     if (options.extract) {
       return ExtractTextPlugin.extract({
-        loader: sourceLoader,
-        fallbackLoader: 'vue-style-loader'
+        use: sourceLoader,
+        fallback: 'vue-style-loader'
       })
     } else {
       return ['vue-style-loader', sourceLoader].join('!')

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -34,7 +34,9 @@ var webpackConfig = merge(baseWebpackConfig, {
       }
     }),
     // extract css into its own file
-    new ExtractTextPlugin(utils.assetsPath('css/[name].[contenthash].css')),
+    new ExtractTextPlugin({
+      filename: utils.assetsPath('css/[name].[contenthash].css')
+    }),
     // generate dist index.html with correct asset hash for caching.
     // you can customize output by editing /index.html
     // see https://github.com/ampedandwired/html-webpack-plugin


### PR DESCRIPTION
`extract-text-webpack-plugin` changed its interface in version 2, per documentation here: https://webpack.js.org/guides/migrating/#extracttextwebpackplugin-breaking-change

I've updated the settings in the webpack config accordingly.