### PR TITLE
Update deprecated config

### DIFF
--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -29,8 +29,8 @@ exports.cssLoaders = function (options) {
     // (which is the case during production build)
     if (options.extract) {
       return ExtractTextPlugin.extract({
-        loader: sourceLoader,
-        fallbackLoader: 'vue-style-loader'
+        use: sourceLoader,
+        fallback: 'vue-style-loader'
       })
     } else {
       return ['vue-style-loader', sourceLoader].join('!')


### PR DESCRIPTION
After the upgrade to Webpack 2, I'm seeing these warnings when I build.

```
fallbackLoader option has been deprecated - replace with "fallback"
```

and

```
loader option has been deprecated - replace with "use"
```