### PR TITLE
Fix a bug when not using JSLint

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -2,8 +2,10 @@ var path = require('path')
 var utils = require('./utils')
 var config = require('../config')
 var vueLoaderConfig = require('./vue-loader.conf')
+{{#lint}}
 var eslintFriendlyFormatter = require('eslint-friendly-formatter')
-
+{{/lint}}
+  
 function resolve (dir) {
   return path.join(__dirname, '..', dir)
 }


### PR DESCRIPTION
Hello,

I created a webpack project with vue-cli and noticed that I had an error when running `npm run dev` :

```
Error: Cannot find module 'eslint-friendly-formatter'
```

I added the correct code so that the module doesn't get called when you chose to not use any JSLint tool.

Regards,

Romain.