### PR TITLE
Opening index.html works with file://

### DIFF
--- a/template/config/index.js
+++ b/template/config/index.js
@@ -7,7 +7,7 @@ module.exports = {
     index: path.resolve(__dirname, '../dist/index.html'),
     assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'static',
-    assetsPublicPath: '/',
+    assetsPublicPath: './',
     productionSourceMap: true,
     // Gzip off by default as many popular static hosts such as
     // Surge or Netlify already gzip all static assets for you.


### PR DESCRIPTION
Open index.html file without import errors (css and js) and without needing a server