### PR TITLE
Use vue-test for component testing

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -73,6 +73,7 @@
     "inject-loader": "^2.0.1",
     "babel-plugin-istanbul": "^3.1.2",
     "phantomjs-prebuilt": "^2.1.14",
+    "vue-test": "^1.0.0",
     {{/unit}}
     {{#e2e}}
     "chromedriver": "^2.27.2",

--- a/template/test/unit/specs/Hello.spec.js
+++ b/template/test/unit/specs/Hello.spec.js
@@ -1,11 +1,10 @@
-import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import { mount } from 'vue-test'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 import Hello from 'src/components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 describe('Hello.vue', () => {
   it('should render correct contents', () => {
-    const Constructor = Vue.extend(Hello){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-    const vm = new Constructor().$mount(){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-    expect(vm.$el.querySelector('.hello h1').textContent)
+    const el = mount(Hello){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    expect(el.find('h1').text())
       .to.equal('Welcome to Your Vue.js App'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
   }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}


### PR DESCRIPTION
I wrote [vue-test](https://github.com/callumacrae/vue-test) because I didn't like that I had to interact with the Vue internals to test my components. It was especially irritating when I wanted to pass in props to the component, because there's no way to just pass in an object (https://github.com/vuejs/vue/issues/2114).

A couple other people have said they'd find it useful, so I figured I'd send a PR to the template :)

I'm actively using the module as part of my job, so it'll be well maintained. That said, feel free to reject this PR if you feel the library is unnecessary or don't want to add a dependency :)

[vue-test]: https://github.com/callumacrae/vue-test