### PR TITLE
Reference CSS resources using relative paths

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -69,7 +69,9 @@ module.exports = {
         loader: 'url-loader',
         query: {
           limit: 10000,
-          name: utils.assetsPath('fonts/[name].[hash:7].[ext]')
+          name: '[name].[hash:7].[ext]',
+          outputPath: utils.assetsPath('fonts/'),
+          publicPath: process.env.NODE_ENV === 'production' ? '../fonts/' : utils.assetsPath('fonts/')
         }
       }
     ]


### PR DESCRIPTION
When referencing resources (e.g. fonts) in a CSS file, absolute paths are put into the generated CSS file.  If assetsPath is absolute (e.g. '/'), this is OK, but if it's relative (e.g. './'), production builds won't be able to find the assets (because of the absolute rather than relative path).

I created a repo to discuss this issue: https://github.com/asselin/vue-webpack-font-load-bug.  The project pulls in foundation-icons, which references a font in the CSS.  I added 1 icon under "Essential links" in Hello.vue.

Branch  `build_with_relative_assetsPath` changes the assetsPath to './', and showcases the issue.  The font file won't be found if you build for production because the URL put into the CSS is `static/fonts/foundation-icons.a188c2f.woff` (vs. `/static/fonts/foundation-icons.a188c2f.woff` if assetsPath is '/').

Branch `relative_assets_path_with_url-loader_change` applies my fix, which changes the URL in the CSS file to be `../fonts/foundation-icons.a188c2f.woff`.

Branch `Base_template_with_url-loader_change` shows that my change with assetsPath set to '/' still works for dev and prod builds.