### PR TITLE
Change assetsPublicPath for production to ./

### DIFF
--- a/template/build/build.js
+++ b/template/build/build.js
@@ -27,9 +27,5 @@ rm(path.join(config.build.assetsRoot, config.build.assetsSubDirectory), err => {
     }) + '\n\n')
 
     console.log(chalk.cyan('  Build complete.\n'))
-    console.log(chalk.yellow(
-      '  Tip: built files are meant to be served over an HTTP server.\n' +
-      '  Opening index.html over file:// won\'t work.\n'
-    ))
   })
 })

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -7,7 +7,7 @@ module.exports = {
     index: path.resolve(__dirname, '../dist/index.html'),
     assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'static',
-    assetsPublicPath: '/',
+    assetsPublicPath: './',
     productionSourceMap: true,
     // Gzip off by default as many popular static hosts such as
     // Surge or Netlify already gzip all static assets for you.


### PR DESCRIPTION
Also, remove warning message about not working over file://

This PR fixes #200 to enable Cordova, file://, and serving from a higher directory (e.g. building into test/dist and serving test/).

Also see PR #530 related to this one, which fixes a similar type of path issue loading fonts.