### PR TITLE
Let generateLoaders can handle multiple loaders.

### DIFF
--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -20,15 +20,33 @@ exports.cssLoaders = function (options) {
     }
   }
 
-  // generate loader string to be used with extract text plugin
-  function generateLoaders (loader, loaderOptions) {
-    var loaders = [cssLoader]
-    if (loader) {
-      loaders.push({
+  // generate loader string and object to loader config object
+  function generateLoader (loader) {
+    if (typeof loader === 'string') {
+      return {
         loader: loader + '-loader',
-        options: Object.assign({}, loaderOptions, {
+        options: {
           sourceMap: options.sourceMap
-        })
+        }
+      }
+    } else if (typeof loader === 'object' && loader.constructor === Object) {
+      return loader
+    }
+  }
+
+  // generate loader string, object, array to be used with extract text plugin
+  function generateLoaders (loader) {
+    var loaders = [cssLoader]
+
+    if (loader) {
+      // wrap string & object to array
+      if (typeof loader === 'string' ||
+        (typeof loader === 'object' && loader.constructor === Object)) {
+        loader = [loader]
+      }
+
+      loader.forEach(item => {
+        loaders.push(generateLoader(item))
       })
     }
 
@@ -49,8 +67,26 @@ exports.cssLoaders = function (options) {
     css: generateLoaders(),
     postcss: generateLoaders(),
     less: generateLoaders('less'),
-    sass: generateLoaders('sass', { indentedSyntax: true }),
-    scss: generateLoaders('sass'),
+    sass: generateLoaders([
+      {
+        loader: 'sass-loader',
+        options: {
+          sourceMap: options.sourceMap,
+          indentedSyntax: true
+        }
+      }
+    ]),
+    scss: generateLoaders([
+      'sass'/*,
+      // you can need sass-resources-loader for your sass
+      {
+        loader: 'sass-resources-loader',
+        options: {
+          // must choose a scss file
+          resources: path.join(__dirname, '../src/config.scss')
+        }
+      }*/
+    ]),
     stylus: generateLoaders('stylus'),
     styl: generateLoaders('stylus')
   }

--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -20,20 +20,6 @@ exports.cssLoaders = function (options) {
     }
   }
 
-  // generate loader string and object to loader config object
-  function generateLoader (loader) {
-    if (typeof loader === 'string') {
-      return {
-        loader: loader + '-loader',
-        options: {
-          sourceMap: options.sourceMap
-        }
-      }
-    } else if (typeof loader === 'object' && loader.constructor === Object) {
-      return loader
-    }
-  }
-
   // generate loader string, object, array to be used with extract text plugin
   function generateLoaders (loader) {
     var loaders = [cssLoader]
@@ -46,7 +32,7 @@ exports.cssLoaders = function (options) {
       }
 
       loader.forEach(item => {
-        loaders.push(generateLoader(item))
+        loaders.push(handleLoader(item))
       })
     }
 
@@ -59,6 +45,20 @@ exports.cssLoaders = function (options) {
       })
     } else {
       return ['vue-style-loader'].concat(loaders)
+    }
+  }
+
+  // generate loader string and object to loader config object
+  function handleLoader (loader) {
+    if (typeof loader === 'string') {
+      return {
+        loader: loader + '-loader',
+        options: {
+          sourceMap: options.sourceMap
+        }
+      }
+    } else if (typeof loader === 'object' && loader.constructor === Object) {
+      return loader
     }
   }
 


### PR DESCRIPTION
Let generateLoaders can handle multiple loaders. If developer want to add more than one loaders, they can add a array to set loader and loader's config.