### PR TITLE
(doc): Added a note on npm run dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ $ npm install
 $ npm run dev
 ```
 
+If port 8080 is already in use on your machine you must change the port number in `/config/index.js`. Otherwise `npm run dev` will fail.
+
 ## What's Included
 
 - `npm run dev`: first-in-class development experience.


### PR DESCRIPTION
If port 8080 is in use on the machine npm run dev will fail without too much information to go on. reading through issues it looked like several people has experienced this and the first comment is always if port 8080 is in use. This edit might get more people going faster.