### PR TITLE
Update .eslintrc.js to make vuex work with airbnb eslint rules.

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -44,6 +44,8 @@ module.exports = {
       'js': 'never',
       'vue': 'never'
     }],
+    // allow vuex
+    'no-param-reassign': ["error", { 'props': false }],
     // allow optionalDependencies
     'import/no-extraneous-dependencies': ['error', {
       'optionalDependencies': ['test/unit/index.js']


### PR DESCRIPTION
By default, vuex mutations
```javascript
  mutations: {
    increment (state) {
      // mutate state
      state.count++
    }
  }
```
cannot pass airbnb eslint rules. 

Update .eslintrc.js to make it work.