### PR TITLE
(docs): Remove broken link to deployment notes

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -20,7 +20,6 @@ All build commands are executed via [NPM Scripts](https://docs.npmjs.com/misc/sc
 - HTML minified with [html-minifier](https://github.com/kangax/html-minifier).
 - CSS across all components extracted into a single file and minified with [cssnano](https://github.com/ben-eb/cssnano).
 - All static assets compiled with version hashes for efficient long-term caching, and a production `index.html` is auto-generated with proper URLs to these generated assets.
-- Also see [deployment notes](#how-do-i-deploy-built-assets-with-my-backend-framework).
 
 ### `npm run unit`
 


### PR DESCRIPTION
- Remove anchor reference to non-existent anchor

note: I could not find a reference to "deployment notes"... it may be referencing `backend.md`, which is already linked to in the same block.