### PR TITLE
shell script capture stdout errors

### DIFF
--- a/template/build/build.js
+++ b/template/build/build.js
@@ -18,6 +18,12 @@ rm(path.join(config.build.assetsRoot, config.build.assetsSubDirectory), err => {
   webpack(webpackConfig, function (err, stats) {
     spinner.stop()
     if (err) throw err
+    /* The exit command terminates a script */
+    if(stats.hasErrors()) {
+      process.on('exit', function() {
+        process.exit(2)
+      })
+    }
     process.stdout.write(stats.toString({
       colors: true,
       modules: false,


### PR DESCRIPTION
在集成在jenkins中，`npm run build` 如果有错误，shell script 不能捕获这些错误信息，导致任务一直往下执行。

我在 `build/build.js` 添加如下

``` javascript
/* The exit command terminates a script */
if(stats.hasErrors()) {
  process.on('exit', function() {
    process.exit(2)
  })
}
```

In the integrated jenkins, If there is an error  in the process of `npm run build`, the shell script can not capture these error messages, causing the task to continue until the next implementation.

``` javascript
/* The exit command terminates a script */
if(stats.hasErrors()) {
  process.on('exit', function() {
    process.exit(2)
  })
}
```