### PR TITLE
Updated .gitignore to exclude log files with suffixes

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,8 +1,9 @@
 .DS_Store
 node_modules/
 dist/
-npm-debug.log
-yarn-error.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
 {{#unit}}
 test/unit/coverage
 {{/unit}}


### PR DESCRIPTION
e.g file: npm-debug.log.4178510676
partially fixes #554
reference: https://github.com/github/gitignore/blob/master/Node.gitignore