### PR TITLE
Fix #598 - Split vendor css into its own file

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -70,7 +70,7 @@ var webpackConfig = merge(baseWebpackConfig, {
         // any required modules inside node_modules are extracted to vendor
         return (
           module.resource &&
-          /\.js$/.test(module.resource) &&
+          /\.(css|js)$/.test(module.resource) &&
           module.resource.indexOf(
             path.join(__dirname, '../node_modules')
           ) === 0


### PR DESCRIPTION
For the same reasons it's done for js, in order to:

1. Limit the number of network requests, ...
2. ... while ensuring to make the slowly-changing `vendor.<hash>.css` as cache-friendly as possible.

Works as expected and emits a separate vendor css+sourcemap couple.

Thanks to @asafyish for the pointer!