### PR TITLE
fix watch&reload for sub folders under src/

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -43,7 +43,8 @@ module.exports = {
       {
         test: /\.vue$/,
         loader: 'vue-loader',
-        options: vueLoaderConfig
+        options: vueLoaderConfig,
+        include: [resolve('src'), resolve('test')]
       },
       {
         test: /\.js$/,


### PR DESCRIPTION
when running dev in an ubuntu16.04 docker image (files mounted from a centos host), changes to src/componets/*.vue will not trigger recompilation thus no hotreloading. Adding an include entry solved this problem