### PR TITLE
Fix eslint issue when running unit tests

### DIFF
--- a/template/test/unit/index.js
+++ b/template/test/unit/index.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+
 Vue.config.productionTip = false{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 // Polyfill fn.bind() for PhantomJS


### PR DESCRIPTION
When running unit tests, eslint declares an error because of the missing empty line after import

```
ERROR in ./test/unit/index.js

  ✘  https://google.com/#q=import%2Fnewline-after-import  Expected empty line after import statement not followed by another import  
  /home/toilal/idea-projects/vue-test-upstream/test/unit/index.js:1:1
  import Vue from 'vue';
   ^


✘ 1 problem (1 error, 0 warnings)
```
