### PR TITLE
Fix typo in nightwatch.conf.js

### DIFF
--- a/template/test/e2e/nightwatch.conf.js
+++ b/template/test/e2e/nightwatch.conf.js
@@ -1,7 +1,7 @@
 require('babel-register')
 var config = require('../../config')
 
-// http://nightwatchjs.org/getingstarted#settings-file
+// http://nightwatchjs.org/gettingstarted#settings-file
 module.exports = {
   src_folders: ['test/e2e/specs'],
   output_folder: 'test/e2e/reports',


### PR DESCRIPTION
Fix typo in the URL which point to the docs commented in the nightwatch.conf.js file