### PR TITLE
Fixed naming of Airbnb in linter config

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -59,9 +59,9 @@ module.exports = {
           "short": "Standard"
         },
         {
-          "name": "AirBNB (https://github.com/airbnb/javascript)",
+          "name": "Airbnb (https://github.com/airbnb/javascript)",
           "value": "airbnb",
-          "short": "AirBNB"
+          "short": "Airbnb"
         },
         {
           "name": "none (configure it yourself)",


### PR DESCRIPTION
Hello 👋 

Love this template, my go-to of all options. I've discovered a very minor naming issue though, and this fixes it. The official writing style is [_Airbnb_](https://github.com/airbnb) and not _AirBNB_.

❤️ 