### PR TITLE
Don't require NPM, let users also use Yarn (fix#656)

### DIFF
--- a/template/build/check-versions.js
+++ b/template/build/check-versions.js
@@ -1,7 +1,7 @@
 var chalk = require('chalk')
 var semver = require('semver')
 var packageConfig = require('../package.json')
-
+var shell = require('shelljs')
 function exec (cmd) {
   return require('child_process').execSync(cmd).toString().trim()
 }
@@ -12,12 +12,15 @@ var versionRequirements = [
     currentVersion: semver.clean(process.version),
     versionRequirement: packageConfig.engines.node
   },
-  {
+]
+
+if (shell.which('npm')) {
+  versionRequirements.push({
     name: 'npm',
     currentVersion: exec('npm --version'),
     versionRequirement: packageConfig.engines.npm
-  }
-]
+  })
+}
 
 module.exports = function () {
   var warnings = []

--- a/template/package.json
+++ b/template/package.json
@@ -82,6 +82,7 @@
     "selenium-server": "^3.0.1",
     {{/e2e}}
     "semver": "^5.3.0",
+    "shelljs": "^0.7.6",
     "opn": "^4.0.2",
     "optimize-css-assets-webpack-plugin": "^1.3.0",
     "ora": "^1.1.0",


### PR DESCRIPTION
if no npm installed, not to check npm version