### PR TITLE
Upgrade url-loader to ^0.5.8

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -88,7 +88,7 @@
     "optimize-css-assets-webpack-plugin": "^1.3.0",
     "ora": "^1.1.0",
     "rimraf": "^2.6.0",
-    "url-loader": "^0.5.7",
+    "url-loader": "^0.5.8",
     "vue-loader": "^11.1.4",
     "vue-style-loader": "^2.0.0",
     "vue-template-compiler": "^2.2.4",


### PR DESCRIPTION
When you require a module which handle by url-loader 
`example: main.js ===> require('assets/img/logo.png'))`
An error may be reported
```
Module build failed: Error: parseQuery should get a string as first argument
```
`loader-utils@0.2.16` was fixed this issue and `url-loader@0.5.8` has been upgraded `loader-utils` to `v1.1.0`