### PR TITLE
Adding port detection to dev-server

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -31,6 +31,7 @@
     "connect-history-api-fallback": "^1.3.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.26.1",
+    "detect-port": "^1.0.5",
     {{#lint}}
     "eslint": "^3.14.1",
     "eslint-friendly-formatter": "^2.0.7",


### PR DESCRIPTION
When default port is occupied, pick another one and start the app on that port. Very useful when running multiple projects at the same time.