### PR TITLE
alias sass-loader to scss-loader for unit testing

### DIFF
--- a/template/build/webpack.test.conf.js
+++ b/template/build/webpack.test.conf.js
@@ -11,6 +11,11 @@ var webpackConfig = merge(baseConfig, {
     rules: utils.styleLoaders()
   },
   devtool: '#inline-source-map',
+  resolveLoader: {
+    alias: {
+      'scss-loader': 'sass-loader'
+    }
+  },
   plugins: [
     new webpack.DefinePlugin({
       'process.env': require('../config/test.env')

--- a/template/build/webpack.test.conf.js
+++ b/template/build/webpack.test.conf.js
@@ -13,6 +13,8 @@ var webpackConfig = merge(baseConfig, {
   devtool: '#inline-source-map',
   resolveLoader: {
     alias: {
+      // necessary to to make lang="scss" work in test when using vue-loader's ?inject option 
+      // see discussion at https://github.com/vuejs/vue-loader/issues/724
       'scss-loader': 'sass-loader'
     }
   },


### PR DESCRIPTION
Adding this alias allows vue-loader to work in injection mode when using lang="scss" in a component.

Please see https://github.com/vuejs/vue-loader/issues/724

Thanks to @rsoule3 for finding a fix.



