### PR TITLE
Add es6-promise to Karma configuration

### DIFF
--- a/template/test/unit/karma.conf.js
+++ b/template/test/unit/karma.conf.js
@@ -14,7 +14,10 @@ module.exports = function (config) {
     browsers: ['PhantomJS'],
     frameworks: ['mocha', 'sinon-chai', 'phantomjs-shim'],
     reporters: ['spec', 'coverage'],
-    files: ['./index.js'],
+    files: [
+      '../../node_modules/es6-promise/dist/es6-promise.auto.js',
+      './index.js'
+    ],
     preprocessors: {
       './index.js': ['webpack', 'sourcemap']
     },


### PR DESCRIPTION
When using Vuex, this prevents the error
```[vuex] vuex requires a Promise polyfill in this browser```
as per @adambiggs' solution here:
https://github.com/vuejs-templates/webpack/issues/474#issuecomment-279082315

The `es6-promise` package is guaranteed to be installed
as a indirect dependency of `phantomjs-prebuilt`,
but perhaps it should be added as an explicit dependency if the user
chooses to include unit testing.