### PR TITLE
Have simple JS object for configuration proposal

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -2,7 +2,7 @@ require('./check-versions')()
 
 var config = require('../config')
 if (!process.env.NODE_ENV) {
-  process.env.NODE_ENV = JSON.parse(config.dev.env.NODE_ENV)
+  process.env.NODE_ENV = config.dev.env.NODE_ENV
 }
 
 var opn = require('opn')

--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -69,3 +69,12 @@ exports.styleLoaders = function (options) {
   }
   return output
 }
+
+exports.envVarsToDefinePlugin = function (envObj) {
+  return Object.keys(envObj).map(function (k) {
+    return [k, "'" + envObj[k] + "'"]
+  }).reduce(function (o, e) {
+    o[e[0]] = e[1]
+    return o
+  }, {})
+}

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -19,7 +19,7 @@ module.exports = merge(baseWebpackConfig, {
   devtool: '#cheap-module-eval-source-map',
   plugins: [
     new webpack.DefinePlugin({
-      'process.env': JSON.stringify(config.dev.env)
+      'process.env': utils.envVarsToDefinePlugin(config.dev.env)
     }),
     // https://github.com/glenjamin/webpack-hot-middleware#installation--usage
     new webpack.HotModuleReplacementPlugin(),

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -19,7 +19,7 @@ module.exports = merge(baseWebpackConfig, {
   devtool: '#cheap-module-eval-source-map',
   plugins: [
     new webpack.DefinePlugin({
-      'process.env': config.dev.env
+      'process.env': JSON.stringify(config.dev.env)
     }),
     // https://github.com/glenjamin/webpack-hot-middleware#installation--usage
     new webpack.HotModuleReplacementPlugin(),

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -29,7 +29,7 @@ var webpackConfig = merge(baseWebpackConfig, {
   plugins: [
     // http://vuejs.github.io/vue-loader/en/workflow/production.html
     new webpack.DefinePlugin({
-      'process.env': JSON.stringify(env)
+      'process.env': utils.envVarsToDefinePlugin(env)
     }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -29,7 +29,7 @@ var webpackConfig = merge(baseWebpackConfig, {
   plugins: [
     // http://vuejs.github.io/vue-loader/en/workflow/production.html
     new webpack.DefinePlugin({
-      'process.env': env
+      'process.env': JSON.stringify(env)
     }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {

--- a/template/build/webpack.test.conf.js
+++ b/template/build/webpack.test.conf.js
@@ -13,7 +13,7 @@ var webpackConfig = merge(baseConfig, {
   devtool: '#inline-source-map',
   plugins: [
     new webpack.DefinePlugin({
-      'process.env': JSON.stringify(require('../config/test.env'))
+      'process.env': utils.envVarsToDefinePlugin(require('../config/test.env'))
     })
   ]
 })

--- a/template/build/webpack.test.conf.js
+++ b/template/build/webpack.test.conf.js
@@ -13,7 +13,7 @@ var webpackConfig = merge(baseConfig, {
   devtool: '#inline-source-map',
   plugins: [
     new webpack.DefinePlugin({
-      'process.env': require('../config/test.env')
+      'process.env': JSON.stringify(require('../config/test.env'))
     })
   ]
 })

--- a/template/config/dev.env.js
+++ b/template/config/dev.env.js
@@ -2,5 +2,5 @@ var merge = require('webpack-merge')
 var prodEnv = require('./prod.env')
 
 module.exports = merge(prodEnv, {
-  NODE_ENV: '"development"'
+  NODE_ENV: 'development'
 })

--- a/template/config/prod.env.js
+++ b/template/config/prod.env.js
@@ -1,3 +1,3 @@
 module.exports = {
-  NODE_ENV: '"production"'
+  NODE_ENV: 'production'
 }

--- a/template/config/test.env.js
+++ b/template/config/test.env.js
@@ -2,5 +2,5 @@ var merge = require('webpack-merge')
 var devEnv = require('./dev.env')
 
 module.exports = merge(devEnv, {
-  NODE_ENV: '"testing"'
+  NODE_ENV: 'testing'
 })


### PR DESCRIPTION
Proposal for #667 

At the end, my initial idea didn't work as I expected; although, as I commented, I did such change in the build templates files of the application which I'm working on, I didn't realize that the value injected in the `process.env` were expected object (the first commits on this PR reflected those changes), because webpack v1 didn't build an invalid build and I was at the beginning of the application that I'm building, so I was not using any value from the `process.env` object inside of my application at that moment, hence I never saw any issue.

When I migrated to webpack v2 template, manually; I found an error in the web console when I was serving the build (dev and prod) and I didn't understand what I missed in such upgrade, threofre I reverted my changes in the template build files and upgraded the template to the current version, without messing arround with personal changes.

Working in this proposal, I've realized that such error was due the changes that I've done in the first commit of this PR, so I had to create a simple helper function to achieve what I expressed in #667 

I haven't squashed the commits because it provide context to this commet, if you like this and you want to merge, I can squash them if you want to.