### PR TITLE
Add support for linked modules

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -1,10 +1,11 @@
 var path = require('path')
+var fs = require('fs')
 var utils = require('./utils')
 var config = require('../config')
 var vueLoaderConfig = require('./vue-loader.conf')
 
 function resolve (dir) {
-  return path.join(__dirname, '..', dir)
+  return fs.realpathSync(__dirname + '/' + path.join('..', dir))
 }
 
 module.exports = {
@@ -24,8 +25,9 @@ module.exports = {
       {{#if_eq build "standalone"}}
       'vue$': 'vue/dist/vue.esm.js',
       {{/if_eq}}
-      '@': resolve('src')
-    }
+      '@': resolve('src'),
+    },
+    symlinks: false
   },
   module: {
     rules: [


### PR DESCRIPTION
After this change I was able to develop with locally-linked packages using `$ yarn link`/`$ npm link`.