### PR TITLE
Only use .vue files in karma and ignore the rest of files

### DIFF
--- a/template/test/unit/index.js
+++ b/template/test/unit/index.js
@@ -6,8 +6,8 @@ Vue.config.productionTip = false{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 const testsContext = require.context('./specs', true, /\.spec$/){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 testsContext.keys().forEach(testsContext){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
-// require all src files except main.js for coverage.
+// require all vue files except main.js (and external files) for coverage.
 // you can also change this to match only the subset of files that
 // you want coverage for.
-const srcContext = require.context('../../src', true, /^\.\/(?!main(\.js)?$)/){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+const srcContext = require.context('../../src', true, /^\.\/(?!main\.js$).+\.(js|vue)$/i){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 srcContext.keys().forEach(srcContext){{#if_eq lintConfig "airbnb"}};{{/if_eq}}


### PR DESCRIPTION
Currently, if you want to do unit test and we use external files, such as html, css, pug, sass, etc ... we need to load the loaders by hand in ' webpack.test.conf.js`. Vue-loader already has all loaders needed, so if we only use the .vue files from our components, vue-loader will be in charge of processing everything (templates and styles included)

Thanks :smile: