### PR TITLE
Updating packages to latest and greatest.

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -18,12 +18,12 @@
     "vue-router": "^2.3.1"{{/router}}
   },
   "devDependencies": {
-    "autoprefixer": "^6.7.2",
+    "autoprefixer": "^7.1.0",
     "babel-core": "^6.22.1",
     {{#lint}}
     "babel-eslint": "^7.1.1",
     {{/lint}}
-    "babel-loader": "^6.2.10",
+    "babel-loader": "^7.0.0",
     "babel-plugin-transform-runtime": "^6.22.0",
     "babel-preset-env": "^1.3.2",
     "babel-preset-stage-2": "^6.22.0",
@@ -34,13 +34,15 @@
     "css-loader": "^0.28.0",
     {{#lint}}
     "eslint": "^3.19.0",
-    "eslint-friendly-formatter": "^2.0.7",
+    "eslint-friendly-formatter": "^3.0.0",
     "eslint-loader": "^1.7.1",
     "eslint-plugin-html": "^2.0.0",
     {{#if_eq lintConfig "standard"}}
-    "eslint-config-standard": "^6.2.1",
+    "eslint-config-standard": "^10.2.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-node": "^4.2.2",
     "eslint-plugin-promise": "^3.4.0",
-    "eslint-plugin-standard": "^2.0.1",
+    "eslint-plugin-standard": "^3.0.1",
     {{/if_eq}}
     {{#if_eq lintConfig "airbnb"}}
     "eslint-config-airbnb-base": "^11.1.3",
@@ -57,7 +59,7 @@
     "http-proxy-middleware": "^0.17.3",
     "webpack-bundle-analyzer": "^2.2.1",
     {{#unit}}
-    "cross-env": "^4.0.0",
+    "cross-env": "^5.0.0",
     "karma": "^1.4.1",
     "karma-coverage": "^1.1.1",
     "karma-mocha": "^1.3.0",
@@ -65,7 +67,7 @@
     "karma-phantomjs-shim": "^1.4.0",
     "karma-sinon-chai": "^1.3.1",
     "karma-sourcemap-loader": "^0.3.7",
-    "karma-spec-reporter": "0.0.30",
+    "karma-spec-reporter": "0.0.31",
     "karma-webpack": "^2.0.2",
     "lolex": "^1.5.2",
     "mocha": "^3.2.0",
@@ -84,13 +86,13 @@
     {{/e2e}}
     "semver": "^5.3.0",
     "shelljs": "^0.7.6",
-    "opn": "^4.0.2",
+    "opn": "^5.0.0",
     "optimize-css-assets-webpack-plugin": "^1.3.0",
     "ora": "^1.2.0",
     "rimraf": "^2.6.0",
     "url-loader": "^0.5.8",
-    "vue-loader": "^11.3.4",
-    "vue-style-loader": "^2.0.5",
+    "vue-loader": "^12.0.4",
+    "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.2.6",
     "webpack": "^2.3.3",
     "webpack-dev-middleware": "^1.10.0",


### PR DESCRIPTION
Executed _npm outdated_ and had the following results:

autoprefixer 6.7.7 6.7.7  7.1.0
babel-loader                 6.4.1   6.4.1   7.0.0 
cross-env                    4.0.0   4.0.0   5.0.0 
eslint-config-standard       6.2.1   6.2.1  10.2.1 
eslint-friendly-formatter    2.0.7   2.0.7   3.0.0 
eslint-plugin-standard       2.3.1   2.3.1   3.0.1 
karma-spec-reporter         0.0.30  0.0.30  0.0.31 
opn                          4.0.2   4.0.2   5.0.0 
vue-loader                  11.3.4  11.3.4  12.0.4 
vue-style-loader             2.0.5   2.0.5   3.0.1 

I updated the packages to reflect the version changes.  This also required adding the following two packages for ESLint

eslint-plugin-import  2.2.0
eslint-plugin-node  4.2.2

Please advise if there are additional changes i can make or help with.

Thank you!