### PR TITLE
Fix hot reload, if install template with Yarn

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -27,7 +27,11 @@ var compiler = webpack(webpackConfig)
 
 var devMiddleware = require('webpack-dev-middleware')(compiler, {
   publicPath: webpackConfig.output.publicPath,
-  quiet: true
+  quiet: true,
+  watchOptions: {
+    aggregateTimeout: 300,
+    poll: 1000
+  }
 })
 
 var hotMiddleware = require('webpack-hot-middleware')(compiler, {


### PR DESCRIPTION
Hi, 
The hot reload does not work if we install the template via yarn, when I add the last piece of code it works, after why exactly that bug with yarn, I do not know.

Thanks