### PR TITLE
Add CDN feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 node_modules
 .DS_Store
 docs/_book

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ If port 8080 is already in use on your machine you must change the port number i
   - HTML minified with [html-minifier](https://github.com/kangax/html-minifier).
   - CSS across all components extracted into a single file and minified with [cssnano](https://github.com/ben-eb/cssnano).
   - All static assets compiled with version hashes for efficient long-term caching, and a production `index.html` is auto-generated with proper URLs to these generated assets.
+  - Ability to reference libraries from a CDN of your choice when building in production, falling back to node_modules when developing.
   - Use `npm run build --report`to build with bundle size analytics.
 
 - `npm run unit`: Unit tests run in PhantomJS with [Karma](http://karma-runner.github.io/0.13/index.html) + [Mocha](http://mochajs.org/) + [karma-webpack](https://github.com/webpack/karma-webpack).

--- a/meta.js
+++ b/meta.js
@@ -42,7 +42,8 @@ module.exports = {
     },
     "cdn": {
       "type": "confirm",
-      "message": "Use a CDN when building for production?"
+      "message": "Use a CDN when building for production?",
+      "default": false
     },
     "cdnConfig": {
       "when": "cdn",

--- a/meta.js
+++ b/meta.js
@@ -40,6 +40,27 @@ module.exports = {
         }
       ]
     },
+    "cdn": {
+      "type": "confirm",
+      "message": "Use a CDN when building for production?"
+    },
+    "cdnConfig": {
+      "when": "cdn",
+      "type": "list",
+      "message": "Pick a CDN repository",
+      "choices": [
+        {
+          "name": "unpkg.com",
+          "value": "unpkg",
+          "short": "unpkg"
+        },
+        {
+          "name": "cdnjs.cloudflare.com",
+          "value": "cdnjs",
+          "short": "cdnjs"
+        }
+      ]
+    },
     "router": {
       "type": "confirm",
       "message": "Install vue-router?"

--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -63,7 +63,8 @@ app.use(hotMiddleware)
 
 // serve pure static assets
 var staticPath = path.posix.join(config.dev.assetsPublicPath, config.dev.assetsSubDirectory)
-app.use(staticPath, express.static('./static'))
+app.use(staticPath, express.static('./static')){{#cdn}}
+app.use('/libraries', express.static('./node_modules')){{/cdn}}
 
 var uri = 'http://localhost:' + port
 

--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -4,7 +4,8 @@ var config = require('../config')
 var merge = require('webpack-merge')
 var baseWebpackConfig = require('./webpack.base.conf')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
-var FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin')
+var FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin'){{#cdn}}
+var WebpackCdnPlugin = require('webpack-cdn-plugin'){{/cdn}}
 
 // add hot-reload related code to entry chunks
 Object.keys(baseWebpackConfig.entry).forEach(function (name) {
@@ -29,7 +30,8 @@ module.exports = merge(baseWebpackConfig, {
       filename: 'index.html',
       template: 'index.html',
       inject: true
-    }),
+    }),{{#cdn}}
+    new WebpackCdnPlugin({modules: config.build.packages, prod: false, publicPath: '/libraries'}),{{/cdn}}
     new FriendlyErrorsPlugin()
   ]
 })

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -7,7 +7,8 @@ var baseWebpackConfig = require('./webpack.base.conf')
 var CopyWebpackPlugin = require('copy-webpack-plugin')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
-var OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
+var OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin'){{#cdn}}
+var WebpackCdnPlugin = require('webpack-cdn-plugin'){{/cdn}}
 
 var env = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'
   ? require('../config/test.env')
@@ -66,7 +67,11 @@ var webpackConfig = merge(baseWebpackConfig, {
       },
       // necessary to consistently work with multiple chunks via CommonsChunkPlugin
       chunksSortMode: 'dependency'
-    }),
+    }),{{#if cdn}}
+    new WebpackCdnPlugin({
+      modules: config.build.packages{{#if_eq cdnConfig "cdnjs"}},
+      prodUrl: '//cdnjs.cloudflare.com/ajax/libs/:name/:version/:path'{{/if_eq}}
+    }),{{else}}
     // split vendor js into its own file
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',
@@ -86,7 +91,7 @@ var webpackConfig = merge(baseWebpackConfig, {
     new webpack.optimize.CommonsChunkPlugin({
       name: 'manifest',
       chunks: ['vendor']
-    }),
+    }),{{/if}}
     // copy custom static assets
     new CopyWebpackPlugin([
       {

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -7,7 +7,19 @@ module.exports = {
     index: path.resolve(__dirname, '../dist/index.html'),
     assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'static',
-    assetsPublicPath: '/',
+    assetsPublicPath: '/',{{#cdn}}
+    packages: [
+      {
+        name: 'vue',
+        var: 'Vue',
+        path: 'dist/vue.runtime.min.js'
+      },
+      {
+        name: 'vue-router',
+        var: 'VueRouter',
+        path: 'dist/vue-router.min.js'
+      }
+    ],{{/cdn}}
     productionSourceMap: true,
     // Gzip off by default as many popular static hosts such as
     // Surge or Netlify already gzip all static assets for you.

--- a/template/package.json
+++ b/template/package.json
@@ -94,6 +94,9 @@
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.3.3",
     "webpack": "^2.6.1",
+    {{#cdn}}
+    "webpack-cdn-plugin": "^1.3.4",
+    {{/cdn}}
     "webpack-dev-middleware": "^1.10.0",
     "webpack-hot-middleware": "^2.18.0",
     "webpack-merge": "^4.1.0"


### PR DESCRIPTION
Enhances html-webpack-plugin functionality by allowing you to specify the modules you want to externalize from node_modules in development and a CDN in production.

Basically this will allow you to greatly reduce build time when developing and improve page load performance on production.