### PR TITLE
make the webpack hot module reloader work with a publicPath set

### DIFF
--- a/template/build/dev-client.js
+++ b/template/build/dev-client.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 require('eventsource-polyfill')
-var hotClient = require('webpack-hot-middleware/client?dynamicPublicPath=true&noInfo=true&reload=true')
+var hotClient = require('webpack-hot-middleware/client?dynamicPublicPath=true&path=__webpack_hmr&noInfo=true&reload=true')
 
 hotClient.subscribe(function (event) {
   if (event.action === 'reload') {

--- a/template/build/dev-client.js
+++ b/template/build/dev-client.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 require('eventsource-polyfill')
-var hotClient = require('webpack-hot-middleware/client?noInfo=true&reload=true')
+var hotClient = require('webpack-hot-middleware/client?dynamicPublicPath=true&noInfo=true&reload=true')
 
 hotClient.subscribe(function (event) {
   if (event.action === 'reload') {

--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -31,7 +31,9 @@ var devMiddleware = require('webpack-dev-middleware')(compiler, {
 })
 
 var hotMiddleware = require('webpack-hot-middleware')(compiler, {
-  log: () => {}
+	log: () => {},
+	path: webpackConfig.output.publicPath + "/__webpack_hmr"
+
 })
 // force page reload when html-webpack-plugin template changes
 compiler.plugin('compilation', function (compilation) {
@@ -64,7 +66,7 @@ app.use(hotMiddleware)
 var staticPath = path.posix.join(config.dev.assetsPublicPath, config.dev.assetsSubDirectory)
 app.use(staticPath, express.static('./static'))
 
-var uri = 'http://localhost:' + port
+var uri = 'http://localhost:' + port + webpackConfig.output.publicPath
 
 var _resolve
 var readyPromise = new Promise(resolve => {

--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -31,9 +31,8 @@ var devMiddleware = require('webpack-dev-middleware')(compiler, {
 })
 
 var hotMiddleware = require('webpack-hot-middleware')(compiler, {
-	log: () => {},
-	path: webpackConfig.output.publicPath + "/__webpack_hmr"
-
+  log: () => {},
+	path: path.join(webpackConfig.output.publicPath, "__webpack_hmr")
 })
 // force page reload when html-webpack-plugin template changes
 compiler.plugin('compilation', function (compilation) {
@@ -53,7 +52,12 @@ Object.keys(proxyTable).forEach(function (context) {
 })
 
 // handle fallback for HTML5 history API
-app.use(require('connect-history-api-fallback')())
+app.use(
+	require('connect-history-api-fallback')({
+		index: config.dev.assetsPublicPath + 'index.html'
+	})
+);
+
 
 // serve webpack bundle output
 app.use(devMiddleware)


### PR DESCRIPTION
we have multiple apps using VUE webpack project structure and in order for each of them to be able to use the hmr they need to be deployed under each specific app context.