### PR TITLE
fix: process cannot exit immediately when encountering build error

### DIFF
--- a/template/build/build.js
+++ b/template/build/build.js
@@ -18,6 +18,10 @@ rm(path.join(config.build.assetsRoot, config.build.assetsSubDirectory), err => {
   webpack(webpackConfig, function (err, stats) {
     spinner.stop()
     if (err) throw err
+    if (stats.hasErrors()) {
+      console.error(stats.toString('errors-only'))
+      process.exit(1)
+    }
     process.stdout.write(stats.toString({
       colors: true,
       modules: false,


### PR DESCRIPTION
Such as command `npm run build && echo 'build successfully'`, when encountering build error, the console still outputs the info 'build successfully' finally. 
