### PR TITLE
babel should keep code comments. (close #730)

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -4,7 +4,6 @@
     "stage-2"
   ],
   "plugins": ["transform-runtime"],
-  "comments": false,
   "env": {
     "test": {
       "presets": ["env", "stage-2"],


### PR DESCRIPTION
They are necessary for webpacks "magic comments" to work, e.g. with `import(/* webpackChunkName: "chunk1" */ './component.vue')`