### PR TITLE
Use webpack.prod.conf when NODE_ENV === production

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -10,9 +10,9 @@ var path = require('path')
 var express = require('express')
 var webpack = require('webpack')
 var proxyMiddleware = require('http-proxy-middleware')
-var webpackConfig = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'
+var webpackConfig = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing' || {{/if_or}}process.env.NODE_ENV === 'production'
   ? require('./webpack.prod.conf')
-  : {{/if_or}}require('./webpack.dev.conf')
+  : require('./webpack.dev.conf')
 
 // default port where dev server listens for incoming traffic
 var port = process.env.PORT || config.dev.port


### PR DESCRIPTION
When setting NODE_ENV to production locally dev-server.js should use webpack.prod.conf.