### PR TITLE
Specify the address to listen on

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -81,7 +81,7 @@ devMiddleware.waitUntilValid(() => {
   _resolve()
 })
 
-var server = app.listen(port)
+var server = app.listen(port, 'localhost')
 
 module.exports = {
   ready: readyPromise,


### PR DESCRIPTION
Currently, this causes the dev server to listen on all addresses by default, which is not the intended behavior, imo.