### PR TITLE
Use recommended way to disable webpack-hot-middleware log

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -31,7 +31,7 @@ var devMiddleware = require('webpack-dev-middleware')(compiler, {
 })
 
 var hotMiddleware = require('webpack-hot-middleware')(compiler, {
-  log: () => {},
+  log: false,
   heartbeat: 2000
 })
 // force page reload when html-webpack-plugin template changes


### PR DESCRIPTION
For disabling logs for `hotMiddleware`, we need not pass a `noop`, we can use `false`.

Relevant docs - https://github.com/glenjamin/webpack-hot-middleware#middleware