### PR TITLE
Added support for TypeScript (as an option)

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -40,6 +40,10 @@ module.exports = {
         }
       ]
     },
+    "typescript": {
+      "type": "confirm",
+      "message": "Setup Vue build with TypeScript?"
+    },
     "router": {
       "type": "confirm",
       "message": "Install vue-router?"
@@ -86,7 +90,10 @@ module.exports = {
     "test/unit/**/*": "unit",
     "build/webpack.test.conf.js": "unit",
     "test/e2e/**/*": "e2e",
-    "src/router/**/*": "router"
+    "src/router/**/*": "router",
+    "src/**/*.ts": "typescript",
+    "tsconfig.json": "typescript",
+    "src/**/*.js": "!typescript"
   },
   "completeMessage": "To get started:\n\n  {{^inPlace}}cd {{destDirName}}\n  {{/inPlace}}npm install\n  npm run dev\n\nDocumentation can be found at https://vuejs-templates.github.io/webpack"
 };

--- a/template/build/vue-loader.conf.js
+++ b/template/build/vue-loader.conf.js
@@ -8,5 +8,6 @@ module.exports = {
       ? config.build.productionSourceMap
       : config.dev.cssSourceMap,
     extract: isProduction
-  })
+  }){{#typescript}},
+    esModule: true{{/typescript}}
 }

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -9,7 +9,7 @@ function resolve (dir) {
 
 module.exports = {
   entry: {
-    app: './src/main.js'
+    app: './src/main.{{#typescript}}t{{else}}j{{/typescript}}s'
   },
   output: {
     path: config.build.assetsRoot,
@@ -19,7 +19,7 @@ module.exports = {
       : config.dev.assetsPublicPath
   },
   resolve: {
-    extensions: ['.js', '.vue', '.json'],
+    extensions: ['.js', '.vue', '.json'{{#typescript}},'.ts'{{/typescript}}],
     alias: {
       {{#if_eq build "standalone"}}
       'vue$': 'vue/dist/vue.esm.js',
@@ -44,7 +44,16 @@ module.exports = {
         test: /\.vue$/,
         loader: 'vue-loader',
         options: vueLoaderConfig
+      },{{#typescript}}
+      // Documentation @ https://www.npmjs.com/package/ts-loader
+      {
+        test: /\.ts$/,
+        loader: 'ts-loader',
+        options: {
+          appendTsSuffixTo: [/\.vue$/]
+        }
       },
+      {{/typescript}}
       {
         test: /\.js$/,
         loader: 'babel-loader',

--- a/template/package.json
+++ b/template/package.json
@@ -15,7 +15,10 @@
   },
   "dependencies": {
     "vue": "^2.3.3"{{#router}},
-    "vue-router": "^2.3.1"{{/router}}
+    "vue-router": "^2.3.1"{{/router}}{{#typescript}},
+    "ts-loader": "^2.2.1",
+    "typescript": "^2.4.1",
+    "vue-class-component": "^5.0.1"{{/typescript}}
   },
   "devDependencies": {
     "autoprefixer": "^6.7.2",

--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -8,17 +8,30 @@
     {{/router}}
   </div>
 </template>
-
-<script>
+{{#typescript}}
+<!-- For *.vue files, <script>'s  need to have a lang="ts" -->
+{{/typescript}}
+<script {{#typescript}}lang="ts"{{/typescript}}>
+{{#typescript}}
+import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import Component from 'vue-class-component'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+{{/typescript}}
 {{#unless router}}
-import Hello from './components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import Hello from './components/Hello{{#typescript}}.vue{{/typescript}}'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 {{/unless}}
-export default {
-  name: 'app'{{#router}}{{#if_eq lintConfig "airbnb"}},{{/if_eq}}{{else}},
+{{#typescript}}
+@Component{{#unless router}}({
+  components: {
+    'hello': Hello
+  }
+}){{/unless}}
+export default class App extends Vue{{else}}
+export default{{/typescript}} {
+  name{{#typescript}} ={{else}}:{{/typescript}} 'app'{{#router}}{{#if_eq lintConfig "airbnb"}},{{/if_eq}}{{else}}{{#unless typescript}}
   components: {
     Hello{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
-  }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}{{/router}}
+  }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}{{/unless}}{{/router}}
 }{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 </script>
 

--- a/template/src/components/Hello.vue
+++ b/template/src/components/Hello.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="hello">
     <h1>\{{ msg }}</h1>
-    <h2>Essential Links</h2>
+    <h2 class="class2">Essential Links</h2>
     <ul>
       <li><a href="https://vuejs.org" target="_blank">Core Docs</a></li>
       <li><a href="https://forum.vuejs.org" target="_blank">Forum</a></li>
@@ -20,9 +20,15 @@
   </div>
 </template>
 
-<script>
-export default {
-  name: 'hello',
+<script {{#typescript}}lang="ts"{{/typescript}}>
+{{#typescript}}
+import Vue from 'vue'
+import Component from 'vue-class-component'
+
+@Component
+export default class Hello extends Vue{{else}}
+export default{{/typescript}} {
+  name{{#typescript}} ={{else}}:{{/typescript}} 'hello'{{#unless typescript}},{{/unless}}
   data{{#unless_eq lintConfig "airbnb"}} {{/unless_eq}}() {
     return {
       msg: 'Welcome to Your Vue.js App'{{#if_eq lintConfig "airbnb"}},{{/if_eq}}

--- a/template/src/main.ts
+++ b/template/src/main.ts
@@ -1,0 +1,26 @@
+{{#if_eq build "standalone"}}
+// The Vue build version to load with the `import` command
+// (runtime-only or standalone) has been set in webpack.base.conf with an alias.
+{{/if_eq}}
+import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import App from './App.vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+{{#router}}
+import router from './router'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+{{/router}}
+
+Vue.config.productionTip = false{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+
+/* eslint-disable no-new */
+new Vue({
+  el: '#app',
+  {{#router}}
+  router,
+  {{/router}}
+  {{#if_eq build "runtime"}}
+  render: h => h(App){{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+  {{/if_eq}}
+  {{#if_eq build "standalone"}}
+  template: '<App/>',
+  components: { App }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+  {{/if_eq}}
+}){{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/src/router/index.ts
+++ b/template/src/router/index.ts
@@ -1,0 +1,15 @@
+import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import Router from 'vue-router'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import Hello from '@/components/Hello{{#typescript}}.vue{{/typescript}}'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+
+Vue.use(Router){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+
+export default new Router({
+  routes: [
+    {
+      path: '/',
+      name: 'Hello',
+      component: Hello{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+    }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+  ]{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+}){{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/src/vue-shims.d.ts
+++ b/template/src/vue-shims.d.ts
@@ -1,0 +1,4 @@
+declare module "*.vue" {
+  import Vue from 'vue'
+  export default typeof Vue
+}

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -1,0 +1,63 @@
+// Options list @ https://www.typescriptlang.org/docs/handbook/compiler-options.html
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "moduleResolution": "node",
+    "lib": [
+      "dom",
+      "es5",
+      "es2015.promise"
+    ],                             /* Specify library files to be included in the compilation:  */
+    "watch": true,
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                            /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+
+    /* Source Map Options */
+    "sourceRoot": "./src",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    "experimentalDecorators": true        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
I've added TypeScript to prompt.

I used a combination of ts-loader, vue-class-components, and a Vue shim for single file "*.vue" components.

Instead of implementing a way of modifying the file extensions (i.e. js -> ts), I just added a filter rule to remove whichever isn't used. (This can probably be improved.)

Hopefully this will help others who are trying to use Vue with TypeScript.

## Testing
I haven't tested all combinations of the options in the prompt. However, I did test with all the options selected, all the options not selected (except TS), and with the options vue-router and TS.