### PR TITLE
Add ESLint rule to allow trailing commas

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -37,6 +37,8 @@ module.exports = {
     'arrow-parens': 0,
     // allow async-await
     'generator-star-spacing': 0,
+    // allow trailing commas
+    'comma-dangle': ['error', 'only-multiline'],
     {{/if_eq}}
     {{#if_eq lintConfig "airbnb"}}
     // don't require .vue extension when importing


### PR DESCRIPTION
In the lines of reducing the **cognitive load** on programmers and reducing the **amount of changed lines** in pull requests, I propose that default ESLint rules should allow trailing commas in multi-line situations. Always checking, adding and removing these commas during development (eg. when adding and commenting out Vue.js data and methods) is an unnecessary cognitive load. They are valid according to ECMAScript 3, and because we nowadays use trans-compilers, they can remove it for IE8.

- <http://eslint.org/docs/rules/comma-dangle>

Inspiration came from the reasoning about semicolon-less code by [evanyou](http://slides.com/evanyou/semicolons) and [smolinari])(https://forum.vuejs.org/t/semicolon-less-code-my-thoughts/4229), where the biggest argument is the cognitive load semicolons bring:

> Adding semicolons adds cognitive load to programming in Javascript, because there are more decisions that need to be made about where to properly add semicolons, than there are, when you simply omit them.

In my opinion disallowing trailing commas represents an even higher cognitive load, more unnecessary problems during development, and a more concise diff output for pull requests.