### PR TITLE
Bump dev dependencies for template

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -18,25 +18,26 @@
     "vue-router": "^2.3.1"{{/router}}
   },
   "devDependencies": {
-    "autoprefixer": "^6.7.2",
+    "autoprefixer": "^7.1.2",
     "babel-core": "^6.22.1",
     {{#lint}}
     "babel-eslint": "^7.1.1",
     {{/lint}}
-    "babel-loader": "^6.2.10",
+    "babel-loader": "^7.1.1",
     "babel-plugin-transform-runtime": "^6.22.0",
     "babel-preset-env": "^1.3.2",
     "babel-preset-stage-2": "^6.22.0",
     "babel-register": "^6.22.0",
-    "chalk": "^1.1.3",
+    "chalk": "^2.0.1",
     "connect-history-api-fallback": "^1.3.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.28.0",
+    "cssnano": "^3.10.0",
     {{#lint}}
     "eslint": "^3.19.0",
-    "eslint-friendly-formatter": "^2.0.7",
+    "eslint-friendly-formatter": "^3.0.0",
     "eslint-loader": "^1.7.1",
-    "eslint-plugin-html": "^2.0.0",
+    "eslint-plugin-html": "^3.0.0",
     {{#if_eq lintConfig "standard"}}
     "eslint-config-standard": "^6.2.1",
     "eslint-plugin-promise": "^3.4.0",
@@ -57,7 +58,7 @@
     "http-proxy-middleware": "^0.17.3",
     "webpack-bundle-analyzer": "^2.2.1",
     {{#unit}}
-    "cross-env": "^4.0.0",
+    "cross-env": "^5.0.1",
     "karma": "^1.4.1",
     "karma-coverage": "^1.1.1",
     "karma-mocha": "^1.3.0",
@@ -65,7 +66,7 @@
     "karma-phantomjs-shim": "^1.4.0",
     "karma-sinon-chai": "^1.3.1",
     "karma-sourcemap-loader": "^0.3.7",
-    "karma-spec-reporter": "0.0.30",
+    "karma-spec-reporter": "0.0.31",
     "karma-webpack": "^2.0.2",
     "lolex": "^1.5.2",
     "mocha": "^3.2.0",
@@ -84,8 +85,8 @@
     {{/e2e}}
     "semver": "^5.3.0",
     "shelljs": "^0.7.6",
-    "opn": "^4.0.2",
-    "optimize-css-assets-webpack-plugin": "^1.3.0",
+    "opn": "^5.1.0",
+    "optimize-css-assets-webpack-plugin": "^2.0.0",
     "ora": "^1.2.0",
     "rimraf": "^2.6.0",
     "url-loader": "^0.5.8",


### PR DESCRIPTION
### Updated libraries

|Library|Current|Latest|Major?|Reason|
|-------|-------|------|------|------|
|autoprefier|6.7.2|7.1.2|Yes|Drop support for node 0.12 [🔗](https://github.com/postcss/autoprefixer/blob/master/CHANGELOG.md)|
|babel-loader|6.2.10|7.1.1|Yes|Drop support for node < 4, webpack 1 [🔗](https://github.com/babel/babel-loader/releases)|
|chalk|1.1.3|2.0.1|Yes|API changes, Drop support for node < 4 [🔗](https://github.com/chalk/chalk/releases)|
|cross-env|4.0.0|5.0.1|Yes|Scripts using quotes or escape sequences will see a difference in behavior. [🔗](https://github.com/kentcdodds/cross-env/releases)|
|eslint-friendly-formatter|2.0.7|3.0.0|Yes|Make relative paths the default again in err reports [🔗](https://github.com/royriojas/eslint-friendly-formatter/blob/master/changelog.md)|
|eslint-plugin-html|2.0.0|3.0.0|Yes|lint script tags separately [🔗](https://github.com/BenoitZugmeyer/eslint-plugin-html/blob/master/CHANGELOG.md)|
|karma-spec-reporter|0.0.30|0.0.31|No|allow prefix overrides on win32 [🔗](https://github.com/mlex/karma-spec-reporter/pull/64)|
|opn|4.0.2|5.1.0|Yes|Drop support for node < 4 [🔗](https://github.com/sindresorhus/opn/compare/b56b0e981ee377d3b04c57a4e6748ad2793ada17...ebae31e9117ae3ca5c9ee642bafa9449f1e237c2)|
|optimize-css-assets-webpack-plugin|1.3.0|2.0.0|Yes|Move cssnano dependency to peerDependencies [🔗](https://github.com/NMFR/optimize-css-assets-webpack-plugin/compare/b5afe3b2bc7fd4720219ca2bf7b31d7b6d03dfef...3b217bc3ca1012003d8626cb7c530179fbf72569)|

### Not updated due to peer dependency

|Library|Current|Latest|Major?|Reason|Peer dependency|PR|
|-------|-------|------|------|------|---------------|--|
|eslint|3.19.0|4.2.0|Yes|New rules in recommended, more strict [🔗](http://eslint.org/docs/user-guide/migrating-to-4.0.0)|[eslint-config-airbnb-base](https://www.npmjs.com/package/eslint-config-airbnb-base)|airbnb/javascript#1447|
|chai|3.5.0|4.0.2|Yes|API changes, Drop support for node < 4 [🔗](http://chaijs.com/releases/)|[karma-sinon-chai](https://github.com/kmees/karma-sinon-chai)|kmees/karma-sinon-chai#48|

Added `cssnano` to `devDependencies` as it is needed for `optimize-css-assets-webpack-plugin` now as peer dependency.

Although `vue-loader` and `webpack` have been updated, I have not bumped their versions as there are significant changes and should be tackled in a different PR.