### PR TITLE
Remove duplicate presets from .babelrc

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -11,7 +11,6 @@
   "plugins": ["transform-runtime"],
   "env": {
     "test": {
-      "presets": ["env", "stage-2"],
       "plugins": ["istanbul"]
     }
   }


### PR DESCRIPTION
Babel environments automatically pick up the default settings. This way the coverage runs on the same output that a normal build would generate.