### PR TITLE
Minimal TypeScript support option added

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -40,6 +40,11 @@ module.exports = {
         }
       ]
     },
+    "typescript": {
+      "type": "confirm",
+      "message": "Use TypeScript as default language?",
+      "default": false
+    },
     "router": {
       "type": "confirm",
       "message": "Install vue-router?"
@@ -86,7 +91,24 @@ module.exports = {
     "test/unit/**/*": "unit",
     "build/webpack.test.conf.js": "unit",
     "test/e2e/**/*": "e2e",
-    "src/router/**/*": "router"
+    "src/router/**/*": "router",
+    "tsconfig.json": "typescript"
   },
-  "completeMessage": "To get started:\n\n  {{^inPlace}}cd {{destDirName}}\n  {{/inPlace}}npm install\n  npm run dev\n\nDocumentation can be found at https://vuejs-templates.github.io/webpack"
+  "completeMessage": "To get started:\n\n  {{^inPlace}}cd {{destDirName}}\n  {{/inPlace}}npm install\n  npm run dev\n\nDocumentation can be found at https://vuejs-templates.github.io/webpack",
+  "metalsmith": function (metalsmith, opts, helpers) {
+    function renameJsSourcesToTs(files, metalsmith, done) {
+      // If typescript is enabled rename any .js files in src/ folder to .ts extension
+      if (metalsmith.metadata().typescript) {
+        Object.keys(files).forEach(filename => {
+          if (/^src.*\.js$/.test(filename)) {
+          const renamed = filename.replace(/\.js$/, ".ts");
+          files[renamed] = files[filename]
+          delete files[filename]
+        }
+      })
+      }
+      done(null, files)
+    }
+    metalsmith.use(renameJsSourcesToTs)
+  }
 };

--- a/meta.js
+++ b/meta.js
@@ -92,7 +92,8 @@ module.exports = {
     "build/webpack.test.conf.js": "unit",
     "test/e2e/**/*": "e2e",
     "src/router/**/*": "router",
-    "tsconfig.json": "typescript"
+    "tsconfig.json": "typescript",
+    "src/vue-shims.d.ts": "typescript"
   },
   "completeMessage": "To get started:\n\n  {{^inPlace}}cd {{destDirName}}\n  {{/inPlace}}npm install\n  npm run dev\n\nDocumentation can be found at https://vuejs-templates.github.io/webpack",
   "metalsmith": function (metalsmith, opts, helpers) {

--- a/template/build/vue-loader.conf.js
+++ b/template/build/vue-loader.conf.js
@@ -14,5 +14,6 @@ module.exports = {
     source: 'src',
     img: 'src',
     image: 'xlink:href'
-  }
+  }{{#typescript}},
+  esModule: true{{/typescript}}
 }

--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -9,7 +9,7 @@ function resolve (dir) {
 
 module.exports = {
   entry: {
-    app: './src/main.js'
+    app: './src/main.{{#typescript}}ts{{else}}js{{/typescript}}'
   },
   output: {
     path: config.build.assetsRoot,
@@ -19,7 +19,7 @@ module.exports = {
       : config.dev.assetsPublicPath
   },
   resolve: {
-    extensions: ['.js', '.vue', '.json'],
+    extensions: [{{#typescript}}'.ts', {{/typescript}}'.js', '.vue', '.json'],
     alias: {
       {{#if_eq build "standalone"}}
       'vue$': 'vue/dist/vue.esm.js',
@@ -45,6 +45,15 @@ module.exports = {
         loader: 'vue-loader',
         options: vueLoaderConfig
       },
+      {{#typescript}}
+      {
+        test: /\.ts$/,
+          loader: "ts-loader",
+          options: {
+          appendTsSuffixTo: [/\.vue$/]
+        }
+      },
+      {{/typescript}}
       {
         test: /\.js$/,
         loader: 'babel-loader',

--- a/template/package.json
+++ b/template/package.json
@@ -32,6 +32,10 @@
     "connect-history-api-fallback": "^1.3.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.28.0",
+    {{#typescript}}
+    "ts-loader": "^2.2.2",
+    "typescript": "^2.4.1",
+    {{/typescript}}
     {{#lint}}
     "eslint": "^3.19.0",
     "eslint-friendly-formatter": "^2.0.7",

--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -9,7 +9,7 @@
   </div>
 </template>
 
-<script>
+<script{{#typescript}} lang="ts"{{/typescript}}>
 {{#unless router}}
 import Hello from './components/Hello'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 

--- a/template/src/components/Hello.vue
+++ b/template/src/components/Hello.vue
@@ -20,7 +20,7 @@
   </div>
 </template>
 
-<script>
+<script{{#typescript}} lang="ts"{{/typescript}}>
 export default {
   name: 'hello',
   data{{#unless_eq lintConfig "airbnb"}} {{/unless_eq}}() {

--- a/template/src/vue-shims.d.ts
+++ b/template/src/vue-shims.d.ts
@@ -1,0 +1,4 @@
+declare module "*.vue" {
+  import Vue from "vue";
+  export default Vue;
+}

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "es2015",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "lib": [
+      "dom",
+      "es5",
+      "es2015.promise"
+    ]
+  },
+  "include": [
+    "./src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
This PR adds TypeScript language option to webpack template.

This is basically the same idea as in: https://github.com/vuejs-templates/webpack/pull/781

The main difference is that I've tried to find minimal possible configuration and code changes.
So in this case there's a metalsmith plugin that renames .js files from /src to .ts if typescript option is enabled.
This way there's no need to maintain both .js and .ts sources.
Checked with both TS enabled and disabled.