### PR TITLE
Redirect everything to index.html

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -52,7 +52,12 @@ Object.keys(proxyTable).forEach(function (context) {
 })
 
 // handle fallback for HTML5 history API
-app.use(require('connect-history-api-fallback')())
+app.use(require('connect-history-api-fallback')({
+  disableDotRule: true,
+  rewrites: [
+    {from: /\/app.js/, to: '/app.js'}
+  ]
+}))
 
 // serve webpack bundle output
 app.use(devMiddleware)

--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -53,9 +53,17 @@ Object.keys(proxyTable).forEach(function (context) {
 
 // handle fallback for HTML5 history API
 app.use(require('connect-history-api-fallback')({
+   // this allows to redirect also paths that contain dots
   disableDotRule: true,
   rewrites: [
-    {from: /\/app.js/, to: '/app.js'}
+    { from: /^\/app.js$/,
+      to:'/app.js'
+    },
+    { from: /.*hot-update.(js|json)$/,
+      to: function(context) {
+        return context.parsedUrl.href
+      }
+    }
   ]
 }))
 


### PR DESCRIPTION
It is not obvious that `connect-history-api-fallback` would not redirect a path with a dot in it. See a StackOverflow discussion here:
https://stackoverflow.com/questions/45280091/vue-router-does-not-catch-routes-with-a-dot-in-the-webpack-template/45296055

Let us make redirects slightly more explicit.