### PR TITLE
Return exit code 1 when npm run build fails

### DIFF
--- a/template/build/build.js
+++ b/template/build/build.js
@@ -26,6 +26,11 @@ rm(path.join(config.build.assetsRoot, config.build.assetsSubDirectory), err => {
       chunkModules: false
     }) + '\n\n')
 
+    if (stats.hasErrors()) {
+      console.log(chalk.red('  Build failed with errors.\n'))
+      process.exit(1)
+    }
+
     console.log(chalk.cyan('  Build complete.\n'))
     console.log(chalk.yellow(
       '  Tip: built files are meant to be served over an HTTP server.\n' +


### PR DESCRIPTION
Having issues in CI's because of it returning 0 even when the build is invalid.