### PR TITLE
prioratize loading .vue over .js files

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -19,7 +19,7 @@ module.exports = {
       : config.dev.assetsPublicPath
   },
   resolve: {
-    extensions: ['.js', '.vue', '.json'],
+    extensions: ['.vue', '.js', '.json'],
     alias: {
       {{#if_eq build "standalone"}}
       'vue$': 'vue/dist/vue.esm.js',


### PR DESCRIPTION
this enables use of [vue-loader' Src Imports](https://vue-loader.vuejs.org/en/start/spec.html#src-imports) with the same file base name, e.g.:

`App.vue`
```html
<template> ... </template>
<style> ... </style>
<script src="./App.js"></script>
```
with code in `App.js`