### PR TITLE
Loading webpack.prod.conf when NODE_ENV=production

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -10,7 +10,7 @@ var path = require('path')
 var express = require('express')
 var webpack = require('webpack')
 var proxyMiddleware = require('http-proxy-middleware')
-var webpackConfig = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'
+var webpackConfig = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing' || 'production'
   ? require('./webpack.prod.conf')
   : {{/if_or}}require('./webpack.dev.conf')
 


### PR DESCRIPTION
This is related to #535. As `webpack.prod.conf` is not loaded when `NODE_ENV === 'production'`, the following error is generated when switching to production.  It doesn't happen for `test` or `dev`. 

```
 error  in ./src/App.vue

Module build failed: Error: "extract-text-webpack-plugin" loader is used without the corresponding plugin, refer to https://github.com/webpack/extract-text-webpack-plugin for the usage example
    at Object.pitch (/Users/alain/Documents/workspace/MySampleApp/node_modules/extract-text-webpack-plugin/dist/loader.js:53:11)

 @ ./src/App.vue 2:2-377
 @ ./src/main.js
 @ multi ./build/dev-client ./src/main.js
```
