### PR TITLE
Move Chat: Gitter -> Discord

### DIFF
--- a/template/src/components/Hello.vue
+++ b/template/src/components/Hello.vue
@@ -5,7 +5,7 @@
     <ul>
       <li><a href="https://vuejs.org" target="_blank">Core Docs</a></li>
       <li><a href="https://forum.vuejs.org" target="_blank">Forum</a></li>
-      <li><a href="https://gitter.im/vuejs/vue" target="_blank">Gitter Chat</a></li>
+      <li><a href="https://chat.vuejs.org" target="_blank">Community Chat</a></li>
       <li><a href="https://twitter.com/vuejs" target="_blank">Twitter</a></li>
       <br>
       <li><a href="http://vuejs-templates.github.io/webpack/" target="_blank">Docs for This Template</a></li>


### PR DESCRIPTION
I created a new project using this template.
When I clicked on Gitter chat, I saw the following message:
```NO LONGER MAINTAINED: Please migrate to http://chat.vuejs.org/ for the new and improved community chat```
This PR edits the chat link displayed on the home page.
Currently, chat.vuejs.org points to Discord, but it can later be redirected to someplace else. Hence, we should point the link to "https://chat.vuejs.org" and not "https://discordapp.com/invite/HBherRA".