### PR TITLE
add HashedModuleIdsPlugin when build

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -67,6 +67,8 @@ var webpackConfig = merge(baseWebpackConfig, {
       // necessary to consistently work with multiple chunks via CommonsChunkPlugin
       chunksSortMode: 'dependency'
     }),
+    // keep module.id stable when vender modules does not change
+    new webpack.HashedModuleIdsPlugin(),
     // split vendor js into its own file
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',


### PR DESCRIPTION
use HashedModuleIdsPlugin to keep vendor.[hash].js same when third-party lib does not change
see more [webpack caching](https://webpack.js.org/guides/caching/#module-identifiers)