### PR TITLE
Removing Vue.config.debug usage from documentation

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -41,11 +41,3 @@ So, the environment variables are:
     - API_KEY    = '...'
 
 As we can see, `test.env` inherits the `dev.env` and the `dev.env` inherits the `prod.env`.
-
-### Usage
-
-It is simple to use the environment variables in your code. For example:
-
-```js
-Vue.config.debug = process.env.DEBUG_MODE
-```

--- a/docs/env.md
+++ b/docs/env.md
@@ -41,3 +41,11 @@ So, the environment variables are:
     - API_KEY    = '...'
 
 As we can see, `test.env` inherits the `dev.env` and the `dev.env` inherits the `prod.env`.
+
+### Usage		
+
+It is simple to use the environment variables in your code. For example:		
+
+```js		
+Vue.config.productionTip = process.env.NODE_ENV === 'production'		
+```


### PR DESCRIPTION
It has been removed; https://vuejs.org/v2/guide/migration.html#Vue-config-debug-removed