### PR TITLE
Update to webpack 3.*, bump relevant dependencies (fix #751)

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -35,12 +35,14 @@ var hotMiddleware = require('webpack-hot-middleware')(compiler, {
   heartbeat: 2000
 })
 // force page reload when html-webpack-plugin template changes
-compiler.plugin('compilation', function (compilation) {
-  compilation.plugin('html-webpack-plugin-after-emit', function (data, cb) {
-    hotMiddleware.publish({ action: 'reload' })
-    cb()
-  })
-})
+// currently disabled until this is resolved:
+// https://github.com/jantimon/html-webpack-plugin/issues/680
+// compiler.plugin('compilation', function (compilation) {
+//   compilation.plugin('html-webpack-plugin-after-emit', function (data, cb) {
+//     hotMiddleware.publish({ action: 'reload' })
+//     cb()
+//   })
+// })
 
 // proxy api requests
 Object.keys(proxyTable).forEach(function (context) {

--- a/template/package.json
+++ b/template/package.json
@@ -51,12 +51,12 @@
     {{/lint}}
     "eventsource-polyfill": "^0.9.6",
     "express": "^4.14.1",
-    "extract-text-webpack-plugin": "^2.0.0",
+    "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.11.1",
-    "friendly-errors-webpack-plugin": "^1.1.3",
-    "html-webpack-plugin": "^2.28.0",
+    "friendly-errors-webpack-plugin": "^1.6.1",
+    "html-webpack-plugin": "^2.30.1",
     "http-proxy-middleware": "^0.17.3",
-    "webpack-bundle-analyzer": "^2.2.1",
+    "webpack-bundle-analyzer": "^2.9.0",
     {{#unit}}
     "cross-env": "^5.0.1",
     "karma": "^1.4.1",
@@ -92,9 +92,9 @@
     "vue-loader": "^13.0.4",
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.4.2",
-    "webpack": "^2.6.1",
-    "webpack-dev-middleware": "^1.10.0",
-    "webpack-hot-middleware": "^2.18.0",
+    "webpack": "^3.5.5",
+    "webpack-dev-middleware": "^1.12.0",
+    "webpack-hot-middleware": "^2.18.2",
     "webpack-merge": "^4.1.0"
   },
   "engines": {


### PR DESCRIPTION
This PR updates all webpack-related dependencies to their latest versions.

It also deactivates the code responisble for triggering page reload when `html-webpack-plugin` sees that `index.html` has been changed, because according to https://github.com/jantimon/html-webpack-plugin/issues/680 this is currently buggy and interferes with HMR.

Commenting out this code makes HMR work again.

We will keep an eye on this issue and re-enable this once the problem in `html-webpak-plugin` has been resolved.