### PR TITLE
Remove unused fs require from webpack.base.conf.js

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -1,5 +1,4 @@
 var path = require('path')
-var fs = require('fs')
 var utils = require('./utils')
 var config = require('../config')
 var vueLoaderConfig = require('./vue-loader.conf')


### PR DESCRIPTION
I applied the linter script to config files (a good idea, IMO), and found this `fs` was unused.

Can someone with more familiarity with the project check that the cli doesn't insert anything into this file that uses `fs`? I'm pretty sure it doesn't.