### PR TITLE
Remove duplicate 'start' npm script

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "node build/dev-server.js",
-    "start": "node build/dev-server.js",
+    "start": "npm run dev",
     "build": "node build/build.js"{{#unit}},
     "unit": "cross-env BABEL_ENV=test karma start test/unit/karma.conf.js --single-run"{{/unit}}{{#e2e}},
     "e2e": "node test/e2e/runner.js"{{/e2e}}{{#if_or unit e2e}},


### PR DESCRIPTION
The `start` and `dev` npm scripts are the same. Do you think it would be a good idea to standardize on a single task to run the dev server?

Originally added here: https://github.com/vuejs-templates/webpack/commit/6f7c03d85021c426aaa7465406a43bcf503a13d9