### PR TITLE
Fix small errors in webpack.prod.conf

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This boilerplate is targeted towards large, serious projects and assumes you are somewhat familiar with Webpack and `vue-loader`. Make sure to also read [`vue-loader`'s documentation](http://vuejs.github.io/vue-loader/index.html) for common workflow recipes.
+This boilerplate is targeted towards large, serious projects and assumes you are somewhat familiar with Webpack and `vue-loader`. Make sure to also read [`vue-loader`'s documentation](https://vue-loader.vuejs.org/) for common workflow recipes.
 
 If you just want to try out `vue-loader` or whip out a quick prototype, use the [webpack-simple](https://github.com/vuejs-templates/webpack-simple) template instead.
 

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -72,7 +72,7 @@ var webpackConfig = merge(baseWebpackConfig, {
     // split vendor js into its own file
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',
-      minChunks: function (module, count) {
+      minChunks: function (module) {
         // any required modules inside node_modules are extracted to vendor
         return (
           module.resource &&


### PR DESCRIPTION
I found a two small errors in webpack.prod.conf. One is an unused parameter, deleted in the commit below.

The second issue I need a little input on. [Here](https://github.com/vuejs-templates/webpack/blob/develop/template/build/webpack.prod.conf.js#L104) you're requiring a package that's not installed in the project by default. BUT the option that requires it is turned off by default. 

Do you think it's better to install the package, so users can turn the gzip option on and have everything work right away, or leave the package out of package.json, for quicker download? I think the first option is better, esp. for testing and maintenance of the project. 

Let me know what you think and I'll resolve this second issue and ping for code review.