### PR TITLE
Simplify elementCount custom assertions

### DIFF
--- a/template/test/e2e/custom-assertions/elementCount.js
+++ b/template/test/e2e/custom-assertions/elementCount.js
@@ -18,8 +18,8 @@ exports.assertion = function (selector, count) {
   }
   this.command = function (cb) {
     var self = this{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-    return this.api.execute(function (selector) {
-      return document.querySelectorAll(selector).length{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    return this.api.execute(function (selectorToCount) {
+      return document.querySelectorAll(selectorToCount).length{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
     }, [selector], function (res) {
       cb.call(self, res){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
     }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}

--- a/template/test/e2e/custom-assertions/elementCount.js
+++ b/template/test/e2e/custom-assertions/elementCount.js
@@ -1,11 +1,12 @@
 // A custom Nightwatch assertion.
-// the name of the method is the filename.
-// can be used in tests like this:
+// The assertion name is the filename.
+// Example usage:
 //
 //   browser.assert.elementCount(selector, count)
 //
-// for how to write custom assertions see
+// For more information on custom assertions see:
 // http://nightwatchjs.org/guide#writing-custom-assertions
+
 exports.assertion = function (selector, count) {
   this.message = 'Testing if element <' + selector + '> has count: ' + count{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
   this.expected = count{{#if_eq lintConfig "airbnb"}};{{/if_eq}}


### PR DESCRIPTION
This PR takes care of three things:

1. Slightly improves the file comment.
2. Renames one of two identically named variables that, because of separate scope, are actually pointing to different pieces of memory. The `selector` in the function passed to the browser is not the same data as the `selector` in brackets immediately after it. 
3. Calls a callback directly instead of using `.call()`.

Let me know what you think. #2 was especially confusing to me while I was looking at this file for the first time. If you can think of a better argument name, let me know 🙃.