### PR TITLE
Remove unnecessary ternary in webpack prod config

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -9,10 +9,6 @@ var HtmlWebpackPlugin = require('html-webpack-plugin')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
 
-var env = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'
-  ? require('../config/test.env')
-  : {{/if_or}}config.build.env
-
 var webpackConfig = merge(baseWebpackConfig, {
   module: {
     rules: utils.styleLoaders({
@@ -29,7 +25,7 @@ var webpackConfig = merge(baseWebpackConfig, {
   plugins: [
     // http://vuejs.github.io/vue-loader/en/workflow/production.html
     new webpack.DefinePlugin({
-      'process.env': env
+      'process.env': config.build.env
     }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {


### PR DESCRIPTION
Another small potential cleanup. We don't need to check if we're in a testing environment and change the `env` string in `webpack.prod.conf`'s `webpack.DefinePlugin`. `webpack.test.conf` overrides the `prod` value of `webpack.DefinePlugin` when we're testing.

Or, is there a situation where we would want to run webpack with `webpack.prod.conf` settings, but have webpack think just the node env is `testing`?