### PR TITLE
Standardize baseWebpackConfig variable name

### DIFF
--- a/template/build/webpack.test.conf.js
+++ b/template/build/webpack.test.conf.js
@@ -3,9 +3,9 @@
 var utils = require('./utils')
 var webpack = require('webpack')
 var merge = require('webpack-merge')
-var baseConfig = require('./webpack.base.conf')
+var baseWebpackConfig = require('./webpack.base.conf')
 
-var webpackConfig = merge(baseConfig, {
+var webpackConfig = merge(baseWebpackConfig, {
   // use inline sourcemap for karma-sourcemap-loader
   module: {
     rules: utils.styleLoaders()


### PR DESCRIPTION
Another tiny PR, hope it's not a bother. When poking around and trying to understand what's going on in the webpack files, I noticed `baseWebpackConfig` is named differently in the test file. Standardizing the var name makes it easier to understand / grep for.