### PR TITLE
Make changing port from cli possible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,13 @@ $ npm install -g vue-cli
 $ vue init webpack my-project
 $ cd my-project
 $ npm install
+# run at default port 8080
 $ npm run dev
+# run at port 6060
+$ npm run dev -- --port 6060
 ```
 
-If port 8080 is already in use on your machine you must change the port number in `/config/index.js`. Otherwise `npm run dev` will fail.
+You can change the port at `config/index.js` as well.
 
 ## What's Included
 

--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -16,6 +16,10 @@ var webpackConfig = {{#if_or unit e2e}}(process.env.NODE_ENV === 'testing' || pr
 
 // default port where dev server listens for incoming traffic
 var port = process.env.PORT || config.dev.port
+var portIndex = process.argv.indexOf('--port')
+if (portIndex !== -1) {
+  port = process.argv[portIndex + 1] || port;
+}
 // automatically open browser, if not set will be false
 var autoOpenBrowser = !!config.dev.autoOpenBrowser
 // Define HTTP proxies to your custom API backend


### PR DESCRIPTION
Can pass optional argument to `npm run dev`. like:

`npm run dev -- --port 6060` run at port 6060.