### PR TITLE
Improve build speed with uglify-webpack option.

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -35,7 +35,8 @@ var webpackConfig = merge(baseWebpackConfig, {
       compress: {
         warnings: false
       },
-      sourceMap: true
+      sourceMap: true,
+      parallel: true
     }),
     // extract css into its own file
     new ExtractTextPlugin({


### PR DESCRIPTION
`uglifyjs-webpack` has a parallel option that allows uglify to run in parallel to the main build. This results in a speed increase in the build process.

Time difference with `npm run build` on a fresh template with all options enabled:
Without change: 4896ms
With change: 4474ms
8.6% increase in speed.

On a project I am currently working on:
Without: 13262ms
WIth: 12576ms
5.1% increase in speed.

Others could have higher speed increases with a newer/different CPU.
CPU used: Intel i7-4712HQ

https://github.com/webpack-contrib/uglifyjs-webpack-plugin
