### PR TITLE
Add config option for watch polling.

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -28,7 +28,11 @@ const compiler = webpack(webpackConfig)
 
 const devMiddleware = require('webpack-dev-middleware')(compiler, {
   publicPath: webpackConfig.output.publicPath,
-  quiet: true
+  quiet: true,
+  watchOptions: !config.dev.poll ? undefined : {
+    aggregateTimeout: 300,
+    poll: true,
+  }
 })
 
 const hotMiddleware = require('webpack-hot-middleware')(compiler, {

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -20,7 +20,7 @@ module.exports = {
     // View the bundle analyzer report after build finishes:
     // `npm run build --report`
     // Set to `true` or `false` to always turn it on or off
-    bundleAnalyzerReport: process.env.npm_config_report
+    bundleAnalyzerReport: process.env.npm_config_report,
   },
   dev: {
     env: require('./dev.env'),
@@ -34,6 +34,11 @@ module.exports = {
     // (https://github.com/webpack/css-loader#sourcemaps)
     // In our experience, they generally work as expected,
     // just be aware of this issue when enabling this option.
-    cssSourceMap: false
+    cssSourceMap: false,
+    // In some environments (e.g. Folders in dropbox or similar services)
+    // Webpack's file watcher doesn't work correctly in its default mode,
+    // and consequently, HMR doesn't work as well.
+    // Switching to 'poll' mode solves this for a lot of scenarios.
+    poll: false
   }
 }


### PR DESCRIPTION
There seem to be [quite a lot of environments](https://github.com/vuejs-templates/webpack/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20poll) (e.g. dropbox folders, docker containers, vagrant ...) in which `webpack-dev-middleware`'s default mode for file watching doesn't work correctly, and thus HMR fails.

In those scenarios, switching to a polling mode seems to fix most people's problems. 

This PR adds a new config option for the dev environment to switch to poll mode - this adds the following options to `webpack-dev-middleware`:
```javascript
watchOptions: {
  aggregateTimeout: 300,
  poll: true
},
```