### PR TITLE
Ignore files improvements

### DIFF
--- a/template/.eslintignore
+++ b/template/.eslintignore
@@ -1,6 +1,7 @@
 /build/
 /config/
 /dist/
+/*.js
 {{#unit}}
 /test/unit/coverage/
 {{/unit}}

--- a/template/.eslintignore
+++ b/template/.eslintignore
@@ -1,2 +1,6 @@
-build/*.js
-config/*.js
+/build/
+/config/
+/dist/
+{{#unit}}
+/test/unit/coverage/
+{{/unit}}

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,14 +1,14 @@
 .DS_Store
 node_modules/
-dist/
+/dist/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 {{#unit}}
-test/unit/coverage
+/test/unit/coverage/
 {{/unit}}
 {{#e2e}}
-test/e2e/reports
+/test/e2e/reports/
 selenium-debug.log
 {{/e2e}}
 


### PR DESCRIPTION
### `.eslintignore`
As I understand the file is included for users that use the globally installed `eslint`. Hense I used `eslint --ext .js,.vue` to check the correctness of `.eslintignore`.
#### `.eslintignore` before
```
build/*.js
config/*.js
```
#### What is changed:
- `*.js` suffixes removed because they are not necessary to ignore the whole `build` and `config` directories
- If the `/` prefix is omitted than any `config` or `build` directories in the repository will be ignored (i.e. `src/config/myConfig.js` will not be linted). This PR adds the `/` prefix.
- `*.js` config files from root directory are ignored by ESLint (currently they will fail linting process for `airbnb` style because of `;` absence)
- Unit testing generates *.js files that are contained deep in `/test/unit/coverage/` folder. They will be ignored after PR merge.
- Production build files in `/dist/` will be ignored after PR merge.

### `.gitignore`
- added `/` to several paths (i.e. `/dist/`). So after this PR users will be able to add `src/dist/normalDistribution.js` to `git` repository.
- I **didn't** add `/` prefix to `node_modules/` because any nested `node_modules` folders are usually have related `package.json` and thus are not intended to be committed to source control.

### Used resources 
- [Official gitignore description](https://git-scm.com/docs/gitignore).
- [Official Eslint docs](https://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories)

Any feedback is welcome.