### PR TITLE
Bump ESLint version 

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -33,7 +33,7 @@
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.28.0",
     {{#lint}}
-    "eslint": "^3.19.0",
+    "eslint": "^4.8.0",
     "eslint-friendly-formatter": "^3.0.0",
     "eslint-loader": "^1.7.1",
     "eslint-plugin-html": "^3.0.0",


### PR DESCRIPTION
Hi!
After last dependecy update, "eslint-config-airbnb-base" with "^12.0.1" requires "eslint": "^4.8.0".
At the current moment in package.json set "eslint": "^3.19.0". This breaks the building of the project.
![2017-10-08 1 12 40](https://user-images.githubusercontent.com/3511312/31312261-03a73208-abc7-11e7-8729-52e9cbaf74b9.png)
