### PR TITLE
Fix bug in dev-server when a proxyTable entry is a string

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -51,7 +51,7 @@ app.use(hotMiddleware)
 
 // proxy api requests
 Object.keys(proxyTable).forEach(function (context) {
-  const options = proxyTable[context]
+  let options = proxyTable[context]
   if (typeof options === 'string') {
     options = { target: options }
   }


### PR DESCRIPTION
`options` can not be a `const` because it is modified if value is a string.