### PR TITLE
Handle unhandled promise rejecion when dev-server.js tries to open a …

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -92,7 +92,7 @@ devMiddleware.waitUntilValid(() => {
     console.log('> Listening at ' + uri + '\n')
     // when env is testing, don't need open it
     if (autoOpenBrowser && process.env.NODE_ENV !== 'testing') {
-      opn(uri)
+      opn(uri).catch(() => {})
     }
     server = app.listen(port)
     _resolve()


### PR DESCRIPTION
Fix for #369, that to silently ignores the promise rejection.

Without this `npm run dev` on nodejs v8.6.0 shows an annoying warning:

```
 DONE  Compiled successfully in 4890ms                                                                                      21:02:38

> Listening at http://localhost:8080

(node:1164) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 3): Error: Exited with code 3
(node:1164) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```