### PR TITLE
replace `id` with `name` in chunk files, Fix #996

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -25,7 +25,7 @@ const webpackConfig = merge(baseWebpackConfig, {
   output: {
     path: config.build.assetsRoot,
     filename: utils.assetsPath('js/[name].[chunkhash].js'),
-    chunkFilename: utils.assetsPath('js/[id].[chunkhash].js')
+    chunkFilename: utils.assetsPath('js/[name].[chunkhash].js')
   },
   plugins: [
     // http://vuejs.github.io/vue-loader/en/workflow/production.html


### PR DESCRIPTION
Use `id` to name the chunk files will lost the `webpackChunkName` somehow. But replace it with `name` will solve this issue.

code:
```javascript
const MainView = () => import(/* webpackChunkName: "group-foo" */ '@/components/MainView')
const OneView = () => import(/* webpackChunkName: "group-foo" */ '@/components/OneView')
const TwoView = () => import(/* webpackChunkName: "group-foo" */ '@/components/TwoView')
```

use `id`:
![1508482209806](https://user-images.githubusercontent.com/13268747/31808770-33ca312a-b53a-11e7-879b-9b76ea079fdf.jpg)

use `name`:
![1508482776777](https://user-images.githubusercontent.com/13268747/31808800-58284c64-b53a-11e7-99d4-61270a85d18c.jpg)


without using any magic comments and it will fallback to `id`:
![1508482833874](https://user-images.githubusercontent.com/13268747/31808882-d2f1dfc8-b53a-11e7-8025-98bb98f2bd63.jpg)
