### PR TITLE
Renamed production command

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "node build/dev-server.js",
     "start": "npm run dev",
-    "build": "node build/build.js"{{#unit}},
+    "prod": "node build/build.js"{{#unit}},
     "unit": "cross-env BABEL_ENV=test karma start test/unit/karma.conf.js --single-run"{{/unit}}{{#e2e}},
     "e2e": "node test/e2e/runner.js"{{/e2e}}{{#if_or unit e2e}},
     "test": "{{#unit}}npm run unit{{/unit}}{{#unit}}{{#e2e}} && {{/e2e}}{{/unit}}{{#e2e}}npm run e2e{{/e2e}}"{{/if_or}}{{#lint}},


### PR DESCRIPTION
To build dev we run `npm run dev` but to build prod we run `npm run build`?
Are you serious?

I am sure it MUST be:
```bash
$ npm run dev
$ npm run prod
```
But only if you want to increase the learning curve, you could leave it like now.