### PR TITLE
airbnb eslint config compatibility with vuex

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -44,6 +44,22 @@ module.exports = {
       'js': 'never',
       'vue': 'never'
     }],
+    // disallow reassignment of function parameters
+    // disallow parameter object manipulation except for specific exclusions
+    'no-param-reassign': ['error', {
+      props: true,
+      ignorePropertyModificationsFor: [
+        'state', // for vuex state
+        'acc', // for reduce accumulators
+        'e', // for e.returnvalue
+        'ctx', // for Koa routing
+        'req', // for Express requests
+        'request', // for Express requests
+        'res', // for Express responses
+        'response', // for Express responses
+        '$scope', // for Angular 1 scopes
+      ]
+    }],
     // allow optionalDependencies
     'import/no-extraneous-dependencies': ['error', {
       'optionalDependencies': ['test/unit/index.js']


### PR DESCRIPTION
Added override to `no-param-reassign` rule to make airbnb eslint config compatible with vuex
Fixes #883