### PR TITLE
Removed unnecessary options from .babelrc

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,10 +1,7 @@
 {
   "presets": [
     ["env", {
-      "modules": false,
-      "targets": {
-        "browsers": ["> 1%", "last 2 versions", "not ie <= 8"]
-      }
+      "modules": false
     }],
     "stage-2"
   ],


### PR DESCRIPTION
Removed unnecessary `target.browsers` property from `babel-preset-env` as `browserslist` is already configured in `package.json`