### PR TITLE
fix the config contradiction about sourceMap in webpack.prod.conf.js

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -47,9 +47,9 @@ const webpackConfig = merge(baseWebpackConfig, {
     // Compress extracted CSS. We are using this plugin so that possible
     // duplicated CSS from different components can be deduped.
     new OptimizeCSSPlugin({
-      cssProcessorOptions: {
-        safe: true
-      }
+      cssProcessorOptions: config.build.productionSourceMap
+      ? { safe: true, map: { inline: false } }
+      : { safe: true }
     }),
     // generate dist index.html with correct asset hash for caching.
     // you can customize output by editing /index.html


### PR DESCRIPTION
current config:

```js
...
module: {
  rules: utils.styleLoaders({
    sourceMap: config.build.productionSourceMap,
    extract: true
  })
},
...
```
```js
...
new OptimizeCSSPlugin({
  cssProcessorOptions: {
    safe: true
  }
}),
...
```

When we use 'optimize-css-assets-webpack-plugin' by this config, we will never get a sourceMap in 'dist/static/css' even if ‘config.build.productionSourceMap‘ is true.

So we have to add some other cssProcessorOptions to get the expected result.
Like this:
```js
...
new OptimizeCSSPlugin({
  cssProcessorOptions: config.build.productionSourceMap
  ? { safe: true, map: { inline: false } }
  : { safe: true }
}),
...
```

reference: https://github.com/NMFR/optimize-css-assets-webpack-plugin/pull/6