### PR TITLE
Set ExtractTextPlugin.allChunks to true

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -42,7 +42,8 @@ const webpackConfig = merge(baseWebpackConfig, {
     }),
     // extract css into its own file
     new ExtractTextPlugin({
-      filename: utils.assetsPath('css/[name].[contenthash].css')
+      filename: utils.assetsPath('css/[name].[contenthash].css'),
+      allChunks: true,
     }),
     // Compress extracted CSS. We are using this plugin so that possible
     // duplicated CSS from different components can be deduped.

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -43,7 +43,10 @@ const webpackConfig = merge(baseWebpackConfig, {
     // extract css into its own file
     new ExtractTextPlugin({
       filename: utils.assetsPath('css/[name].[contenthash].css'),
-      allChunks: true,
+      // set the following options to `true` if you want to extract CSS from
+      // codesplit chunks into this main css file as well.
+      // this will result in *all* of your app's CSS being loaded upfront.
+      allChunks: false,
     }),
     // Compress extracted CSS. We are using this plugin so that possible
     // duplicated CSS from different components can be deduped.

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -43,9 +43,9 @@ const webpackConfig = merge(baseWebpackConfig, {
     // extract css into its own file
     new ExtractTextPlugin({
       filename: utils.assetsPath('css/[name].[contenthash].css'),
-      // set the following options to `true` if you want to extract CSS from
+      // set the following option to `true` if you want to extract CSS from
       // codesplit chunks into this main css file as well.
-      // this will result in *all* of your app's CSS being loaded upfront.
+      // This will result in *all* of your app's CSS being loaded upfront.
       allChunks: false,
     }),
     // Compress extracted CSS. We are using this plugin so that possible


### PR DESCRIPTION
When using CommonsChunkPlugin and there are extracted chunks (from ExtractTextPlugin.extract) in the commons chunk, allChunks must be set to true。

Doc: https://github.com/webpack-contrib/extract-text-webpack-plugin