### PR TITLE
Use webpack 3's standard way to generate a manifest in CommonsChunkPlugin

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -90,7 +90,7 @@ const webpackConfig = merge(baseWebpackConfig, {
     // prevent vendor hash from being updated whenever app bundle is updated
     new webpack.optimize.CommonsChunkPlugin({
       name: 'manifest',
-      chunks: ['vendor']
+      minChunks: Infinity,
     }),
     // copy custom static assets
     new CopyWebpackPlugin([


### PR DESCRIPTION
Use webpack 3's standard way to generate a manifest in CommonsChunkPlugin.

The doc URL: https://webpack.js.org/plugins/commons-chunk-plugin/#manifest-file
* `minChunks` is set to `Infinity` so that only webpack runtime is written to manifest file.
* `chunnks: ['vendor']` is removed as entry chunks are selected if `chunks` is omitted.

This is very useful when using multiple `CommonsChunkPlugin` plugins.