### PR TITLE
fix for (#546) Make public path the app's context

### DIFF
--- a/template/build/dev-client.js
+++ b/template/build/dev-client.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 'use strict'
 require('eventsource-polyfill')
-var hotClient = require('webpack-hot-middleware/client?noInfo=true&reload=true')
+var hotClient = require('webpack-hot-middleware/client?noInfo=true&reload=true&dynamicPublicPath=true&path=__webpack_hmr')
 
 hotClient.subscribe(function (event) {
   if (event.action === 'reload') {

--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -33,6 +33,7 @@ const devMiddleware = require('webpack-dev-middleware')(compiler, {
 
 const hotMiddleware = require('webpack-hot-middleware')(compiler, {
   log: false,
+  path: path.join(webpackConfig.output.publicPath, "__webpack_hmr"),
   heartbeat: 2000
 })
 // force page reload when html-webpack-plugin template changes
@@ -59,16 +60,18 @@ Object.keys(proxyTable).forEach(function (context) {
 })
 
 // handle fallback for HTML5 history API
-app.use(require('connect-history-api-fallback')())
+app.use(
+  require('connect-history-api-fallback')({
+    index: webpackConfig.output.publicPath + 'index.html'
+  })
+)
 
 // serve webpack bundle output
 app.use(devMiddleware)
 
 // serve pure static assets
-const staticPath = path.posix.join(config.dev.assetsPublicPath, config.dev.assetsSubDirectory)
+const staticPath = path.posix.join(webpackConfig.output.publicPath, config.dev.assetsSubDirectory)
 app.use(staticPath, express.static('./static'))
-
-const uri = 'http://localhost:' + port
 
 var _resolve
 var _reject
@@ -88,7 +91,7 @@ devMiddleware.waitUntilValid(() => {
       _reject(err)
     }
     process.env.PORT = port
-    var uri = 'http://localhost:' + port
+    const uri = 'http://localhost:' + port + webpackConfig.output.publicPath
     console.log('> Listening at ' + uri + '\n')
     // when env is testing, don't need open it
     if (autoOpenBrowser && process.env.NODE_ENV !== 'testing') {


### PR DESCRIPTION
setting the config:
```
assetsPublicPath: '/appContext/',
```
results in the app deploying all of it's content under that context 
```
http://localhost:8080/appContext/#/
```
all hot reloading and static asses will be served under that context
