### PR TITLE
Add historyApiFallback in dev-server config

### DIFF
--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -17,6 +17,7 @@ const devWebpackConfig = merge(baseWebpackConfig, {
   
   // these devServer options should be customized in /config/index.js
   devServer: {
+    historyApiFallback: true,
     hot: true,
     host: process.env.HOST || config.dev.host,
     port: process.env.PORT || config.dev.port,


### PR DESCRIPTION
I think this is an important one for a Vue SPA. Also it was used in the previous version of the dev server.

There is also a common addition to historyApiFallback which is :
```
historyApiFallback: {
      disableDotRule: true
}
```

But I don't think that setting this one by default is right.