### PR TITLE
fix(jest): fix Jest coverage directory

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -127,6 +127,7 @@
     },
     "setupFiles": ["<rootDir>/test/unit/setup"],
     "mapCoverage": true,
+    "coverageDirectory": "<rootDir>/test/unit/coverage",
     "collectCoverageFrom" : [
       "src/**/*.{js,vue}",
       "!src/main.js",


### PR DESCRIPTION
Explicitly set the coverage directory to match Karma and `.gitignore`