### PR TITLE
Make sure that imported css files in SFCs are autoprefixed, too

### DIFF
--- a/template/.postcssrc.js
+++ b/template/.postcssrc.js
@@ -3,6 +3,7 @@
 module.exports = {
   "plugins": {
     // to edit target browsers: use "browserslist" field in package.json
+    "postcss-import": {},
     "autoprefixer": {}
   }
 }

--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -14,11 +14,14 @@ exports.assetsPath = function (_path) {
 exports.cssLoaders = function (options) {
   options = options || {}
 
-  const cssLoader = {
-    loader: 'css-loader',
-    options: {
-      minimize: process.env.NODE_ENV === 'production',
-      sourceMap: options.sourceMap
+  function createCssLoader({ importLoaders }) {
+    return {
+      loader: 'css-loader',
+      options: {
+        minimize: process.env.NODE_ENV === 'production',
+        importLoaders,
+        sourceMap: options.sourceMap
+      }
     }
   }
 
@@ -31,6 +34,10 @@ exports.cssLoaders = function (options) {
 
   // generate loader string to be used with extract text plugin
   function generateLoaders (loader, loaderOptions) {
+    let importLoaders = 0
+    if (options.usePostCSS) importLoaders++
+    if (options.usePostCSS && loader) importLoaders++
+    const cssLoader = createCssLoader({ importLoaders })
     const loaders = options.usePostCSS ? [cssLoader, postcssLoader] : [cssLoader]
     if (loader) {
       loaders.push({

--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -14,14 +14,11 @@ exports.assetsPath = function (_path) {
 exports.cssLoaders = function (options) {
   options = options || {}
 
-  function createCssLoader({ importLoaders }) {
-    return {
-      loader: 'css-loader',
-      options: {
-        importLoaders,
-        minimize: process.env.NODE_ENV === 'production',
-        sourceMap: options.sourceMap
-      }
+  const cssLoader = {
+    loader: 'css-loader',
+    options: {
+      minimize: process.env.NODE_ENV === 'production',
+      sourceMap: options.sourceMap
     }
   }
 
@@ -34,8 +31,6 @@ exports.cssLoaders = function (options) {
 
   // generate loader string to be used with extract text plugin
   function generateLoaders (loader, loaderOptions) {
-    const importLoaders = options.usePostCSS && !loader ? 1 : 0
-    const cssLoader = createCssLoader({ importLoaders })
     const loaders = options.usePostCSS ? [cssLoader, postcssLoader] : [cssLoader]
     if (loader) {
       loaders.push({

--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -18,8 +18,8 @@ exports.cssLoaders = function (options) {
     return {
       loader: 'css-loader',
       options: {
-        minimize: process.env.NODE_ENV === 'production',
         importLoaders,
+        minimize: process.env.NODE_ENV === 'production',
         sourceMap: options.sourceMap
       }
     }
@@ -34,9 +34,7 @@ exports.cssLoaders = function (options) {
 
   // generate loader string to be used with extract text plugin
   function generateLoaders (loader, loaderOptions) {
-    let importLoaders = 0
-    if (options.usePostCSS) importLoaders++
-    if (options.usePostCSS && loader) importLoaders++
+    const importLoaders = options.usePostCSS && !loader ? 1 : 0
     const cssLoader = createCssLoader({ importLoaders })
     const loaders = options.usePostCSS ? [cssLoader, postcssLoader] : [cssLoader]
     if (loader) {

--- a/template/package.json
+++ b/template/package.json
@@ -97,6 +97,7 @@
     "nightwatch": "^0.9.12",
     "selenium-server": "^3.0.1",
     {{/e2e}}
+    "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.8",
     "semver": "^5.3.0",
     "shelljs": "^0.7.6",


### PR DESCRIPTION
When using postcss-loader, we have to adjust the `importLoaders` setting in css-loader to re-apply the previous loaders on imported files.

Without this setting, imports in css files will be read as plain css instead of being re-run through postcss, which I think is undesirable.

This is my first, untested attempt.

If any postcss(-loader) guru can chime in, help is welcome.