### PR TITLE
fix webpack-dev-server can't access localhost

### DIFF
--- a/template/config/index.js
+++ b/template/config/index.js
@@ -13,7 +13,7 @@ module.exports = {
     proxyTable: {},
 
     // Various Dev Server settings
-    host: 'localhost', // can be overwritten by process.env.HOST
+    host: '127.0.0.1', // can be overwritten by process.env.HOST
     port: 8080, // can be overwritten by process.env.HOST, if port is in use, a free one will be determined
     autoOpenBrowser: false,
     errorOverlay: true,


### PR DESCRIPTION
 I was unable to access the dev server on localhost:8080 on Mac OSX.  i see some suggest in webpack/webpack-dev-server#183.