### PR TITLE
Revert "remove uneccessary target.browsers (#1004)"

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,7 +1,10 @@
 {
   "presets": [
     ["env", {
-      "modules": false
+      "modules": false,
+      "targets": {
+        "browsers": ["> 1%", "last 2 versions", "not ie <= 8"]
+      }
     }],
     "stage-2"
   ],


### PR DESCRIPTION
The last released version of `babel-preset-env` does not yet support loading the targets from `browserslist` field in `package.json`:

I enabled the debug output for `babel-preset-env` in `.babelrc`:

```diff
diff --git a/.babelrc b/.babelrc
index 3419dae..e4d2dd8 100644
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,8 @@
 {
   "presets": [
     ["env", {
-      "modules": false
+      "modules": false,
+      "debug": true
     }],
     "stage-2"
   ],
```

```
λ yarn list babel-preset-env
yarn list v1.3.2
warning ..\package.json: No license field
warning Filtering by arguments is deprecated. Please use the pattern option instead.
└─ babel-preset-env@1.6.1
Done in 0.96s

λ yarn run build
yarn run v1.3.2
warning ..\package.json: No license field
$ node build/build.js
/ building for production...babel-preset-env: `DEBUG` option

Using targets:
{} // <-Here's the problem

Modules transform: false

Using plugins:
  check-es2015-constants {}
  transform-es2015-arrow-functions {}
  transform-es2015-block-scoped-functions {}
  transform-es2015-block-scoping {}
  transform-es2015-classes {}
  transform-es2015-computed-properties {}
  transform-es2015-destructuring {}
  transform-es2015-duplicate-keys {}
  transform-es2015-for-of {}
  transform-es2015-function-name {}
  transform-es2015-literals {}
  transform-es2015-object-super {}
  transform-es2015-parameters {}
  transform-es2015-shorthand-properties {}
  transform-es2015-spread {}
  transform-es2015-sticky-regex {}
  transform-es2015-template-literals {}
  transform-es2015-typeof-symbol {}
  transform-es2015-unicode-regex {}
  transform-regenerator {}
  transform-exponentiation-operator {}
  transform-async-to-generator {}
  syntax-trailing-function-commas {}
Hash: e84f4e64e9615d747221
Version: webpack 3.8.1
Time: 6312ms
                                                  Asset       Size  Chunks             Chunk Names
               static/js/vendor.4a7dfbcc057d41e2cd2b.js    94.3 kB       0  [emitted]  vendor
                  static/js/app.74a33058aa6f2da49a41.js    11.5 kB       1  [emitted]  app
             static/js/manifest.221cbdbf460b27ff90d1.js    1.51 kB       2  [emitted]  manifest
    static/css/app.d90fac408992be41cff8ba63f004fedd.css  432 bytes       1  [emitted]  app
static/css/app.d90fac408992be41cff8ba63f004fedd.css.map  828 bytes          [emitted]
           static/js/vendor.4a7dfbcc057d41e2cd2b.js.map     769 kB       0  [emitted]  vendor
              static/js/app.74a33058aa6f2da49a41.js.map    37.7 kB       1  [emitted]  app
         static/js/manifest.221cbdbf460b27ff90d1.js.map    14.4 kB       2  [emitted]  manifest
                                             index.html  517 bytes          [emitted]

  Build complete.

  Tip: built files are meant to be served over an HTTP server.
  Opening index.html over file:// won't work.

Done in 10.29s.
```

<details>
<summary>output after adding targets</summary>

```
λ yarn run build
yarn run v1.3.2
warning ..\package.json: No license field
$ node build/build.js
/ building for production...babel-preset-env: `DEBUG` option

Using targets:
{
  "chrome": "60",
  "android": "4.4.3",
  "edge": "15",
  "firefox": "56",
  "ie": "10",
  "ios": "10.3",
  "safari": "10.1"
}

Modules transform: false

Using plugins:
  check-es2015-constants {"android":"4.4.3","ie":"10"}
  transform-es2015-arrow-functions {"android":"4.4.3","ie":"10"}
  transform-es2015-block-scoped-functions {"android":"4.4.3","ie":"10"}
  transform-es2015-block-scoping {"android":"4.4.3","ie":"10"}
  transform-es2015-classes {"android":"4.4.3","ie":"10"}
  transform-es2015-computed-properties {"android":"4.4.3","ie":"10"}
  transform-es2015-destructuring {"android":"4.4.3","edge":"15","ie":"10"}
  transform-es2015-duplicate-keys {"android":"4.4.3","ie":"10"}
  transform-es2015-for-of {"android":"4.4.3","ie":"10"}
  transform-es2015-function-name {"android":"4.4.3","edge":"15","ie":"10"}
  transform-es2015-literals {"android":"4.4.3","ie":"10"}
  transform-es2015-object-super {"android":"4.4.3","ie":"10"}
  transform-es2015-parameters {"android":"4.4.3","ie":"10"}
  transform-es2015-shorthand-properties {"android":"4.4.3","ie":"10"}
  transform-es2015-spread {"android":"4.4.3","ie":"10"}
  transform-es2015-sticky-regex {"android":"4.4.3","ie":"10"}
  transform-es2015-template-literals {"android":"4.4.3","ie":"10"}
  transform-es2015-typeof-symbol {"android":"4.4.3","ie":"10"}
  transform-es2015-unicode-regex {"android":"4.4.3","ie":"10"}
  transform-regenerator {"android":"4.4.3","ie":"10"}
  transform-exponentiation-operator {"android":"4.4.3","ie":"10"}
  transform-async-to-generator {"android":"4.4.3","ie":"10"}
  syntax-trailing-function-commas {"android":"4.4.3","ie":"10"}
Hash: e84f4e64e9615d747221
Version: webpack 3.8.1
Time: 6234ms
                                                  Asset       Size  Chunks             Chunk Names
               static/js/vendor.4a7dfbcc057d41e2cd2b.js    94.3 kB       0  [emitted]  vendor
                  static/js/app.74a33058aa6f2da49a41.js    11.5 kB       1  [emitted]  app
             static/js/manifest.221cbdbf460b27ff90d1.js    1.51 kB       2  [emitted]  manifest
    static/css/app.d90fac408992be41cff8ba63f004fedd.css  432 bytes       1  [emitted]  app
static/css/app.d90fac408992be41cff8ba63f004fedd.css.map  828 bytes          [emitted]
           static/js/vendor.4a7dfbcc057d41e2cd2b.js.map     769 kB       0  [emitted]  vendor
              static/js/app.74a33058aa6f2da49a41.js.map    37.7 kB       1  [emitted]  app
         static/js/manifest.221cbdbf460b27ff90d1.js.map    14.4 kB       2  [emitted]  manifest
                                             index.html  517 bytes          [emitted]

  Build complete.

  Tip: built files are meant to be served over an HTTP server.
  Opening index.html over file:// won't work.

Done in 9.67s.
```

</details>
<br>

However, the targets can be removed from `.babelrc` once `@babel/preset-env` is out of beta. 