### PR TITLE
ESLint config clean up

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -34,9 +34,9 @@ module.exports = {
   rules: {
     {{#if_eq lintConfig "standard"}}
     // allow paren-less arrow functions
-    'arrow-parens': 0,
+    'arrow-parens': 'off',
     // allow async-await
-    'generator-star-spacing': 0,
+    'generator-star-spacing': 'off',
     {{/if_eq}}
     {{#if_eq lintConfig "airbnb"}}
     // don't require .vue extension when importing
@@ -50,6 +50,6 @@ module.exports = {
     }],
     {{/if_eq}}
     // allow debugger during development
-    'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
   }
 }

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -22,16 +22,16 @@ module.exports = {
   ],
   {{#if_eq lintConfig "airbnb"}}
   // check if imports actually resolve
-  'settings': {
+  settings: {
     'import/resolver': {
-      'webpack': {
-        'config': 'build/webpack.base.conf.js'
+      webpack: {
+        config: 'build/webpack.base.conf.js'
       }
     }
   },
   {{/if_eq}}
   // add your custom rules here
-  'rules': {
+  rules: {
     {{#if_eq lintConfig "standard"}}
     // allow paren-less arrow functions
     'arrow-parens': 0,
@@ -41,12 +41,12 @@ module.exports = {
     {{#if_eq lintConfig "airbnb"}}
     // don't require .vue extension when importing
     'import/extensions': ['error', 'always', {
-      'js': 'never',
-      'vue': 'never'
+      js: 'never',
+      vue: 'never'
     }],
     // allow optionalDependencies
     'import/no-extraneous-dependencies': ['error', {
-      'optionalDependencies': ['test/unit/index.js']
+      optionalDependencies: ['test/unit/index.js']
     }],
     {{/if_eq}}
     // allow debugger during development

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -33,8 +33,6 @@ module.exports = {
   // add your custom rules here
   rules: {
     {{#if_eq lintConfig "standard"}}
-    // allow paren-less arrow functions
-    'arrow-parens': 'off',
     // allow async-await
     'generator-star-spacing': 'off',
     {{/if_eq}}


### PR DESCRIPTION
I've checked the `.eslintrc.js` configuration and found 2 ways to make it even better.

#### 1. Remove unnecessary quotes from fields

Since we're using .js config we are already abusing JS object literal brevity in other fields. Unquoting these fields brings consistency to ESLint config.

#### 2. Use more explicit ESLint rule settings

Some users of the template are not experts in ESLint configuration. So they might want to dig in and check what's under the hood. I think that using explicit `'error'` `'warn'` and `'off'` should be preferred over `2`, `1` and `0` in this template. These values are taken from [ESLint configuration guide](https://eslint.org/docs/user-guide/configuring#configuring-rules).

#### 3. Remove redundand `'arrow-parens': 'off'`
Also it was weird to find `'arrow-parens': 'off'` in ESLint config (when Standard JS option was selected during project initialization). Standard JS don't specify this rule, so the line has no effect. I think that this line should affect other supported code styles. So I think that we should exclude `'arrow-parens': 'off'` if `Standard JS` was selected as code style option.

### Additional suggestions

While checking the ESLint config I've found that it was desided to disable [Standard JS `'generator-star-spacing'`](https://github.com/standard/eslint-config-standard/blob/176bbdd49bb929119c0227f27f54aa30f4b35e5b/eslintrc.json#L50). I wounder why does non-standard code style is encouraged. I think that it's legacy from older Standard JS versions or some other code style. I suggest to remove the line that disables `'generator-star-spacing'` for Standard JS.