### PR TITLE
* change default host from localhost to 0.0.0.0;

### DIFF
--- a/template/config/index.js
+++ b/template/config/index.js
@@ -13,7 +13,7 @@ module.exports = {
     proxyTable: {},
 
     // Various Dev Server settings
-    host: 'localhost', // can be overwritten by process.env.HOST
+    host: '0.0.0.0', // can be overwritten by process.env.HOST
     port: 8080, // can be overwritten by process.env.PORT, if port is in use, a free one will be determined
     autoOpenBrowser: false,
     errorOverlay: true,


### PR DESCRIPTION
The server will not be accessed via IP if use `localhost` or `127.0.0.1` as host for webpack-dev-server.