### PR TITLE
Prevent third-party libraries from repeatedly importing vue

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -24,7 +24,7 @@ module.exports = {
     extensions: ['.js', '.vue', '.json'],
     alias: {
       {{#if_eq build "standalone"}}
-      'vue$': 'vue/dist/vue.esm.js',
+      'vue$': path.resolve(__dirname, '../node_modules/vue/dist/vue.esm.js'),
       {{/if_eq}}
       '@': resolve('src'),
     }


### PR DESCRIPTION
一些第三方库在引入vue.js到时候，使用如下配置
Some third-party libraries use this configuration when use vue.js
```js
...
externals:  {
    vue: {
      commonjs: 'vue',
      commonjs2: 'vue',
      amd: 'vue',
      root: 'Vue',
      var: 'Vue'
    }
  }
...
```
这使得本地项目在引入第三方库并且打包的时候重新引入vue
此时，打包第三方库时如（vue-material）,第三方库会引入（vue-material/node_modules/vue/dist/vue.esm.js）

It wiil import vue into packaged duplicate

![image](https://note.youdao.com/yws/public/resource/278d9c0e12e1102f272ce094b70a3fa2/xmlnote/84ACE8782B4F419C95C424A643F2D696/1539)

因此，修改此处别名
Therefore, change the 'vue' of alias to 'path.resolve(__dirname, '../node_modules/vue/dist/vue.esm.js'),'


```
// build/webpack.base.conf.js
resolve: {
    extensions: ['.js', '.vue', '.json'],
    alias: {
       'vue$': path.resolve(__dirname, '../node_modules/vue/dist/vue.esm.js'),
      '@': resolve('src')
    }
  },
```
使得webpack打包的时候，始终是打包到同一个vuejs
Then, it will import vue once time
![image](https://note.youdao.com/yws/public/resource/278d9c0e12e1102f272ce094b70a3fa2/xmlnote/37F33C14DE454927B73B2EBAE4A8AF20/1542)