### PR TITLE
Updates the resolve fn to allow for stepping back a dynamic number of directories

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -4,8 +4,12 @@ const utils = require('./utils')
 const config = require('../config')
 const vueLoaderConfig = require('./vue-loader.conf')
 
-function resolve (dir) {
-  return path.join(__dirname, '..', dir)
+function resolve (dir, stepsBack = 1) {
+	return path.resolve(
+		__dirname,
+		...[...Array(stepsBack).keys()].map(i => '..'),
+		dir
+	)
 }
 
 module.exports = {
@@ -27,6 +31,7 @@ module.exports = {
       'vue$': 'vue/dist/vue.esm.js',
       {{/if_eq}}
       '@': resolve('src'),
+      // pastroot: resolve('foo', 2)
     }
   },
   module: {


### PR DESCRIPTION
I'm working on a project where I need to import components and tools from a directory above my project. 

At first I was just `path.join`-ing the alias I needed, but when I looked at the `js` includes I realized I'd need to do that joining again. 

I took a look at the resolve function and modified it a bit to allow me to tell it how many levels I'd like to step back to look for the directory. I added a default option of 1 so that it didn't break any other resolve calls. 

It works nicely in my project so I thought I'd submit a pull request in case anyone else found it helpful. 

Thanks for the consideration.