### PR TITLE
use postcss default in vue-loader options

### DIFF
--- a/template/build/vue-loader.conf.js
+++ b/template/build/vue-loader.conf.js
@@ -10,7 +10,8 @@ const sourceMapEnabled = isProduction
 module.exports = {
   loaders: utils.cssLoaders({
     sourceMap: sourceMapEnabled,
-    extract: isProduction
+    extract: isProduction,
+    usePostCSS: true
   }),
   cssSourceMap: sourceMapEnabled,
   transformToRequire: {


### PR DESCRIPTION
It seems like loader in vue-loader's options contains no postcss, and but it should have.