### PR TITLE
Add option to allow remote access on webpack-dev-server

### DIFF
--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -26,6 +26,7 @@ const devWebpackConfig = merge(baseWebpackConfig, {
     compress: true,
     host: HOST || config.dev.host,
     port: PORT || config.dev.port,
+    disableHostCheck: config.dev.disableHostCheck,
     open: config.dev.autoOpenBrowser,
     overlay: config.dev.errorOverlay
       ? { warnings: false, errors: true }

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -15,6 +15,7 @@ module.exports = {
     // Various Dev Server settings
     host: 'localhost', // can be overwritten by process.env.HOST
     port: 8080, // can be overwritten by process.env.PORT, if port is in use, a free one will be determined
+    disableHostCheck: false, // set `host: '0.0.0.0'` and `disableHostCheck: true` to allow remote access
     autoOpenBrowser: false,
     errorOverlay: true,
     notifyOnErrors: true,


### PR DESCRIPTION
Set this option to allow remote access to webpack dev server (avoid Invalid Header error)