### PR TITLE
Automatically install Dependencies and fix lint errors

### DIFF
--- a/docs/structure.md
+++ b/docs/structure.md
@@ -31,7 +31,7 @@
 ├── .babelrc                    # babel config
 ├── .editorconfig               # indentation, spaces/tabs and similar settings for your editor
 ├── .eslintrc.js                # eslint config
-├── .eslintignore.js            # eslint ignore rules
+├── .eslintignore               # eslint ignore rules
 ├── .gitignore                  # sensible defaults for gitignore
 ├── .postcssrc.js               # postcss config
 ├── index.html                  # index.html template

--- a/meta.js
+++ b/meta.js
@@ -117,7 +117,7 @@ module.exports = {
     ".eslintrc.js": "lint",
     ".eslintignore": "lint",
     "config/test.env.js": "unit || e2e",
-    "build/webpack.test.conf.js": "e2e || (unit && runner === 'karma')",
+    "build/webpack.test.conf.js": "unit && runner === 'karma'",
     "test/unit/**/*": "unit",
     "test/unit/index.js": "unit && runner === 'karma'",
     "test/unit/jest.conf.js": "unit && runner === 'jest'",

--- a/meta.js
+++ b/meta.js
@@ -8,8 +8,8 @@ const {
 } = require('./utils')
 
 module.exports = {
-  "helpers": {
-    "if_or": function (v1, v2, options) {
+  helpers: {
+    if_or: function (v1, v2, options) {
       if (v1 || v2) {
         return options.fn(this);
       }
@@ -17,105 +17,105 @@ module.exports = {
       return options.inverse(this);
     }
   },
-  "prompts": {
-    "name": {
-      "type": "string",
-      "required": true,
-      "message": "Project name"
+  prompts: {
+    name: {
+      type: 'string',
+      required: true,
+      message: 'Project name'
     },
-    "description": {
-      "type": "string",
-      "required": false,
-      "message": "Project description",
-      "default": "A Vue.js project"
+    description: {
+      type: 'string',
+      required: false,
+      message: 'Project description',
+      default: 'A Vue.js project'
     },
-    "author": {
-      "type": "string",
-      "message": "Author"
+    author: {
+      type: 'string',
+      message: 'Author'
     },
-    "build": {
-      "type": "list",
-      "message": "Vue build",
-      "choices": [
+    build: {
+      type: 'list',
+      message: 'Vue build',
+      choices: [
         {
-          "name": "Runtime + Compiler: recommended for most users",
-          "value": "standalone",
-          "short": "standalone"
+          name: 'Runtime + Compiler: recommended for most users',
+          value: 'standalone',
+          short: 'standalone'
         },
         {
-          "name": "Runtime-only: about 6KB lighter min+gzip, but templates (or any Vue-specific HTML) are ONLY allowed in .vue files - render functions are required elsewhere",
-          "value": "runtime",
-          "short": "runtime"
+          name: 'Runtime-only: about 6KB lighter min+gzip, but templates (or any Vue-specific HTML) are ONLY allowed in .vue files - render functions are required elsewhere',
+          value: 'runtime',
+          short: 'runtime'
         }
       ]
     },
-    "router": {
-      "type": "confirm",
-      "message": "Install vue-router?"
+    router: {
+      type: 'confirm',
+      message: 'Install vue-router?'
     },
-    "lint": {
-      "type": "confirm",
-      "message": "Use ESLint to lint your code?"
+    lint: {
+      type: 'confirm',
+      message: 'Use ESLint to lint your code?'
     },
-    "lintConfig": {
-      "when": "lint",
-      "type": "list",
-      "message": "Pick an ESLint preset",
-      "choices": [
+    lintConfig: {
+      when: 'lint',
+      type: 'list',
+      message: 'Pick an ESLint preset',
+      choices: [
         {
-          "name": "Standard (https://github.com/standard/standard)",
-          "value": "standard",
-          "short": "Standard"
+          name: 'Standard (https://github.com/standard/standard)',
+          value: 'standard',
+          short: 'Standard'
         },
         {
-          "name": "Airbnb (https://github.com/airbnb/javascript)",
-          "value": "airbnb",
-          "short": "Airbnb"
+          name: 'Airbnb (https://github.com/airbnb/javascript)',
+          value: 'airbnb',
+          short: 'Airbnb'
         },
         {
-          "name": "none (configure it yourself)",
-          "value": "none",
-          "short": "none"
+          name: 'none (configure it yourself)',
+          value: 'none',
+          short: 'none'
         }
       ]
     },
-    "unit": {
-      "type": "confirm",
-      "message": "Set up unit tests"
+    unit: {
+      type: 'confirm',
+      message: 'Set up unit tests'
     },
-    "runner": {
-      "when": "unit",
-      "type": "list",
-      "message": "Pick a test runner",
-      "choices": [
+    runner: {
+      when: 'unit',
+      type: 'list',
+      message: 'Pick a test runner',
+      choices: [
         {
-          "name": "Jest",
-          "value": "jest",
-          "short": "jest"
+          name: 'Jest',
+          value: 'jest',
+          short: 'jest'
         },
         {
-          "name": "Karma and Mocha",
-          "value": "karma",
-          "short": "karma"
+          name: 'Karma and Mocha',
+          value: 'karma',
+          short: 'karma'
         },
         {
-          "name": "none (configure it yourself)",
-          "value": "noTest",
-          "short": "noTest"
+          name: 'none (configure it yourself)',
+          value: 'noTest',
+          short: 'noTest'
         }
       ]
     },
-    "e2e": {
-      "type": "confirm",
-      "message": "Setup e2e tests with Nightwatch?"
+    e2e: {
+      type: 'confirm',
+      message: 'Setup e2e tests with Nightwatch?'
     },
-    "autoInstall": {
-      "type": "list",
-      "message": "Should we run `npm install` for you after the project has been created? (recommended)",
-      "choices": [
+    autoInstall: {
+      type: 'list',
+      message: 'Should we run `npm install` for you after the project has been created? (recommended)',
+      choices: [
         {
-          "name": "Yes, use NPM",
-          "value": 'npm',
+          name: 'Yes, use NPM',
+          value: 'npm',
           short: 'npm'
         },
         {
@@ -131,27 +131,27 @@ module.exports = {
       ]
     }
   },
-  "filters": {
-    ".eslintrc.js": "lint",
-    ".eslintignore": "lint",
-    "config/test.env.js": "unit || e2e",
-    "build/webpack.test.conf.js": "unit && runner === 'karma'",
-    "test/unit/**/*": "unit",
-    "test/unit/index.js": "unit && runner === 'karma'",
-    "test/unit/jest.conf.js": "unit && runner === 'jest'",
-    "test/unit/karma.conf.js": "unit && runner === 'karma'",
-    "test/unit/specs/index.js": "unit && runner === 'karma'",
-    "test/unit/setup.js": "unit && runner === 'jest'",
-    "test/e2e/**/*": "e2e",
-    "src/router/**/*": "router"
+  filters: {
+    '.eslintrc.js': 'lint',
+    '.eslintignore': 'lint',
+    'config/test.env.js': 'unit || e2e',
+    'build/webpack.test.conf.js': "unit && runner === 'karma'",
+    'test/unit/**/*': 'unit',
+    'test/unit/index.js': "unit && runner === 'karma'",
+    'test/unit/jest.conf.js': "unit && runner === 'jest'",
+    'test/unit/karma.conf.js': "unit && runner === 'karma'",
+    'test/unit/specs/index.js': "unit && runner === 'karma'",
+    'test/unit/setup.js': "unit && runner === 'jest'",
+    'test/e2e/**/*': 'e2e',
+    'src/router/**/*': 'router'
   },
-  "complete": function (data, { chalk }) {
+  'complete': function (data, { chalk }) {
     
     const green = chalk.green
 
     sortDependencies(data, green)
 
-    const cwd = path.join(process.cwd(), data.inPlace ? "" : data.destDirName)
+    const cwd = path.join(process.cwd(), data.inPlace ? '' : data.destDirName)
     
     if (data.autoInstall) {
       installDependencies(cwd, data.autoInstall, green)

--- a/meta.js
+++ b/meta.js
@@ -110,8 +110,25 @@ module.exports = {
       "message": "Setup e2e tests with Nightwatch?"
     },
     "autoInstall": {
-      "type": "confirm",
-      "message": "Should we run `npm install` for you after the project has been created? (strongly recommended)"
+      "type": "list",
+      "message": "Should we run `npm install` for you after the project has been created? (recommended)",
+      "choices": [
+        {
+          "name": "Yes, use NPM",
+          "value": 'npm',
+          short: 'npm'
+        },
+        {
+          name: 'Yes, use Yarn',
+          value: 'yarn',
+          short: 'yarn'
+        },
+        {
+          name: 'No, I will handle that myself',
+          value: false,
+          short: 'no'
+        }
+      ]
     }
   },
   "filters": {
@@ -139,7 +156,7 @@ module.exports = {
     const cwd = path.join(process.cwd(), data.inPlace ? "" : data.destDirName)
     
     if (data.autoInstall) {
-      installDependencies(cwd, green)
+      installDependencies(cwd, data.autoInstall, green)
       .then(() => {
         return runLintFix(cwd, data, green)
       })

--- a/meta.js
+++ b/meta.js
@@ -108,6 +108,10 @@ module.exports = {
     "e2e": {
       "type": "confirm",
       "message": "Setup e2e tests with Nightwatch?"
+    },
+    "autoInstall": {
+      "type": "confirm",
+      "message": "Should we run `npm install` for you after the project has been created? (strongly recommended)"
     }
   },
   "filters": {
@@ -132,12 +136,17 @@ module.exports = {
 
     const cwd = path.join(process.cwd(), data.inPlace ? "" : data.destDirName)
     
-    installDependencies(cwd)
-    .then(() => {
-      return runLintFix(cwd, data)
-    })
-    .then(() => {
+    if (data.autoInstall) {
+      installDependencies(cwd)
+      .then(() => {
+        return runLintFix(cwd, data)
+      })
+      .then(() => {
+        printMessage(data)
+      })
+    } else {
       printMessage(data)
-    })
+    }
+    
   }
 };

--- a/meta.js
+++ b/meta.js
@@ -1,14 +1,11 @@
 const path = require('path');
 const fs = require('fs');
-
-function sortObject(object) {
-  // Based on https://github.com/yarnpkg/yarn/blob/v1.3.2/src/config.js#L79-L85
-  const sortedObject = {};
-  Object.keys(object).sort().forEach(item => {
-    sortedObject[item] = object[item];
-  });
-  return sortedObject;
-}
+const {
+  sortDependencies,
+  installDependencies,
+  runLintFix,
+  printMessage
+} = require('./utils')
 
 module.exports = {
   "helpers": {
@@ -128,19 +125,19 @@ module.exports = {
     "src/router/**/*": "router"
   },
   "complete": function (data) {
-    const packageJsonFile = path.join(
-      data.inPlace ? "" : data.destDirName,
-      "package.json"
-    );
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonFile));
-    packageJson.devDependencies = sortObject(packageJson.devDependencies);
-    packageJson.dependencies = sortObject(packageJson.dependencies);
-    fs.writeFileSync(
-      packageJsonFile,
-      JSON.stringify(packageJson, null, 2) + "\n"
-    );
 
-    const message = `To get started:\n\n  ${data.inPlace ? '' : `cd ${data.destDirName}\n  `}npm install\n  npm run dev\n\nDocumentation can be found at https://vuejs-templates.github.io/webpack`;
-    console.log("\n" + message.split(/\r?\n/g).map(line => "   " + line).join("\n"));
+    // console.log(JSON.stringify(data, null, 2))
+    
+    sortDependencies(data)
+
+    const cwd = path.join(process.cwd(), data.inPlace ? "" : data.destDirName)
+    
+    installDependencies(cwd)
+    .then(() => {
+      return runLintFix(cwd, data)
+    })
+    .then(() => {
+      printMessage(data)
+    })
   }
 };

--- a/meta.js
+++ b/meta.js
@@ -128,24 +128,26 @@ module.exports = {
     "test/e2e/**/*": "e2e",
     "src/router/**/*": "router"
   },
-  "complete": function (data) {
+  "complete": function (data, { chalk }) {
 
     // console.log(JSON.stringify(data, null, 2))
     
-    sortDependencies(data)
+    const green = chalk.green
+
+    sortDependencies(data, green)
 
     const cwd = path.join(process.cwd(), data.inPlace ? "" : data.destDirName)
     
     if (data.autoInstall) {
-      installDependencies(cwd)
+      installDependencies(cwd, green)
       .then(() => {
-        return runLintFix(cwd, data)
+        return runLintFix(cwd, data, green)
       })
       .then(() => {
-        printMessage(data)
+        printMessage(data, green)
       })
     } else {
-      printMessage(data)
+      printMessage(data, chalk)
     }
     
   }

--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -11,15 +11,15 @@
 
 <script>
 {{#unless router}}
-import HelloWorld from './components/HelloWorld'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import HelloWorld from './components/HelloWorld'
 
 {{/unless}}
 export default {
-  name: 'app'{{#router}}{{#if_eq lintConfig "airbnb"}},{{/if_eq}}{{else}},
+  name: 'app'{{#router}}{{else}},
   components: {
-    HelloWorld{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
-  }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}{{/router}}
-}{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    HelloWorld
+  }{{/router}}
+}
 </script>
 
 <style>

--- a/template/src/components/HelloWorld.vue
+++ b/template/src/components/HelloWorld.vue
@@ -25,10 +25,10 @@ export default {
   name: 'HelloWorld',
   data{{#unless_eq lintConfig "airbnb"}} {{/unless_eq}}() {
     return {
-      msg: 'Welcome to Your Vue.js App'{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
-    }{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-  }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
-}{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+      msg: 'Welcome to Your Vue.js App'
+    }
+  }
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/template/src/components/HelloWorld.vue
+++ b/template/src/components/HelloWorld.vue
@@ -23,7 +23,7 @@
 <script>
 export default {
   name: 'HelloWorld',
-  data{{#unless_eq lintConfig "airbnb"}} {{/unless_eq}}() {
+  data () {
     return {
       msg: 'Welcome to Your Vue.js App'
     }

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -2,13 +2,13 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 {{/if_eq}}
-import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-import App from './App'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import Vue from 'vue'
+import App from './App'
 {{#router}}
-import router from './router'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import router from './router'
 {{/router}}
 
-Vue.config.productionTip = false{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+Vue.config.productionTip = false
 
 /* eslint-disable no-new */
 new Vue({
@@ -17,10 +17,10 @@ new Vue({
   router,
   {{/router}}
   {{#if_eq build "runtime"}}
-  render: h => h(App){{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+  render: h => h(App)
   {{/if_eq}}
   {{#if_eq build "standalone"}}
   template: '<App/>',
-  components: { App }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+  components: { App }
   {{/if_eq}}
-}){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+})

--- a/template/src/router/index.js
+++ b/template/src/router/index.js
@@ -1,15 +1,15 @@
-import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-import Router from 'vue-router'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-import HelloWorld from '@/components/HelloWorld'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import Vue from 'vue'
+import Router from 'vue-router'
+import HelloWorld from '@/components/HelloWorld'
 
-Vue.use(Router){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+Vue.use(Router)
 
 export default new Router({
   routes: [
     {
       path: '/',
       name: 'HelloWorld',
-      component: HelloWorld{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
-    }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
-  ]{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
-}){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+      component: HelloWorld
+    }
+  ]
+})

--- a/template/test/e2e/custom-assertions/elementCount.js
+++ b/template/test/e2e/custom-assertions/elementCount.js
@@ -7,20 +7,20 @@
 // for how to write custom assertions see
 // http://nightwatchjs.org/guide#writing-custom-assertions
 exports.assertion = function (selector, count) {
-  this.message = 'Testing if element <' + selector + '> has count: ' + count{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-  this.expected = count{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+  this.message = 'Testing if element <' + selector + '> has count: ' + count
+  this.expected = count
   this.pass = function (val) {
-    return val === this.expected{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    return val === this.expected
   }
   this.value = function (res) {
-    return res.value{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    return res.value
   }
   this.command = function (cb) {
-    var self = this{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    var self = this
     return this.api.execute(function (selector) {
-      return document.querySelectorAll(selector).length{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+      return document.querySelectorAll(selector).length
     }, [selector], function (res) {
-      cb.call(self, res){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-    }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+      cb.call(self, res)
+    })
   }
 }

--- a/template/test/e2e/runner.js
+++ b/template/test/e2e/runner.js
@@ -1,21 +1,21 @@
 // 1. start the dev server using production config
-process.env.NODE_ENV = 'testing'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+process.env.NODE_ENV = 'testing'
 
-const webpack = require('webpack'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-const DevServer = require('webpack-dev-server'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+const webpack = require('webpack')
+const DevServer = require('webpack-dev-server')
 
-const webpackConfig = require('../../build/webpack.prod.conf'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-const devConfigPromise = require('../../build/webpack.dev.conf'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+const webpackConfig = require('../../build/webpack.prod.conf')
+const devConfigPromise = require('../../build/webpack.dev.conf')
 
-let server{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+let server
 
 devConfigPromise.then(devConfig => {
-  const devServerOptions = devConfig.devServer{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-  const compiler = webpack(webpackConfig){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-  server = new DevServer(compiler, devServerOptions){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-  const port = devServerOptions.port{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-  const host = devServerOptions.host{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-  return server.listen(port, host){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+  const devServerOptions = devConfig.devServer
+  const compiler = webpack(webpackConfig)
+  server = new DevServer(compiler, devServerOptions)
+  const port = devServerOptions.port
+  const host = devServerOptions.host
+  return server.listen(port, host)
 })
 .then(() => {
   // 2. run the nightwatch test suite against it
@@ -25,24 +25,24 @@ devConfigPromise.then(devConfig => {
   // or override the environment flag, for example: `npm run e2e -- --env chrome,firefox`
   // For more information on Nightwatch's config file, see
   // http://nightwatchjs.org/guide#settings-file
-  let opts = process.argv.slice(2){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+  let opts = process.argv.slice(2)
   if (opts.indexOf('--config') === -1) {
-    opts = opts.concat(['--config', 'test/e2e/nightwatch.conf.js']){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    opts = opts.concat(['--config', 'test/e2e/nightwatch.conf.js'])
   }
   if (opts.indexOf('--env') === -1) {
-    opts = opts.concat(['--env', 'chrome']){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    opts = opts.concat(['--env', 'chrome'])
   }
 
-  const spawn = require('cross-spawn'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-  const runner = spawn('./node_modules/.bin/nightwatch', opts, { stdio: 'inherit' }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+  const spawn = require('cross-spawn')
+  const runner = spawn('./node_modules/.bin/nightwatch', opts, { stdio: 'inherit' })
 
   runner.on('exit', function (code) {
-    server.close(){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-    process.exit(code){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-  }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    server.close()
+    process.exit(code)
+  })
 
   runner.on('error', function (err) {
-    server.close(){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-    throw err{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-  }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-}){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    server.close()
+    throw err
+  })
+})

--- a/template/test/e2e/specs/test.js
+++ b/template/test/e2e/specs/test.js
@@ -6,7 +6,7 @@ module.exports = {
     // automatically uses dev Server port from /config.index.js
     // default: http://localhost:8080
     // see nightwatch.conf.js
-    const devServer = browser.globals.devServerURL{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    const devServer = browser.globals.devServerURL
 
     browser
       .url(devServer)
@@ -14,6 +14,6 @@ module.exports = {
       .assert.elementPresent('.hello')
       .assert.containsText('h1', 'Welcome to Your Vue.js App')
       .assert.elementCount('img', 1)
-      .end(){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-  }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
-}{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+      .end()
+  }
+}

--- a/template/test/unit/index.js
+++ b/template/test/unit/index.js
@@ -1,13 +1,13 @@
-import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import Vue from 'vue'
 
-Vue.config.productionTip = false{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+Vue.config.productionTip = false
 
 // require all test files (files that ends with .spec.js)
-const testsContext = require.context('./specs', true, /\.spec$/){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-testsContext.keys().forEach(testsContext){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+const testsContext = require.context('./specs', true, /\.spec$/)
+testsContext.keys().forEach(testsContext)
 
 // require all src files except main.js for coverage.
 // you can also change this to match only the subset of files that
 // you want coverage for.
-const srcContext = require.context('../../src', true, /^\.\/(?!main(\.js)?$)/){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-srcContext.keys().forEach(srcContext){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+const srcContext = require.context('../../src', true, /^\.\/(?!main(\.js)?$)/)
+srcContext.keys().forEach(srcContext)

--- a/template/test/unit/karma.conf.js
+++ b/template/test/unit/karma.conf.js
@@ -3,7 +3,7 @@
 // we are also using it with karma-webpack
 //   https://github.com/webpack/karma-webpack
 
-var webpackConfig = require('../../build/webpack.test.conf'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+var webpackConfig = require('../../build/webpack.test.conf')
 
 module.exports = function (config) {
   config.set({
@@ -20,14 +20,14 @@ module.exports = function (config) {
     },
     webpack: webpackConfig,
     webpackMiddleware: {
-      noInfo: true{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+      noInfo: true
     },
     coverageReporter: {
       dir: './coverage',
       reporters: [
         { type: 'lcov', subdir: '.' },
-        { type: 'text-summary' }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
+        { type: 'text-summary' }
       ]
-    }{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
-  }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-}{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    }
+  })
+}

--- a/template/test/unit/specs/HelloWorld.spec.js
+++ b/template/test/unit/specs/HelloWorld.spec.js
@@ -1,11 +1,11 @@
-import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-import HelloWorld from '@/components/HelloWorld'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+import Vue from 'vue'
+import HelloWorld from '@/components/HelloWorld'
 
 describe('HelloWorld.vue', () => {
   it('should render correct contents', () => {
-    const Constructor = Vue.extend(HelloWorld){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-    const vm = new Constructor().$mount(){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    const Constructor = Vue.extend(HelloWorld)
+    const vm = new Constructor().$mount()
     expect(vm.$el.querySelector('.hello h1').textContent)
-    {{#if_eq runner "karma"}}.to.equal('Welcome to Your Vue.js App'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}{{/if_eq}}{{#if_eq runner "jest"}}.toEqual('Welcome to Your Vue.js App'){{#if_eq lintConfig "airbnb"}};{{/if_eq}}{{/if_eq}}
-  }){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
-}){{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+    {{#if_eq runner "karma"}}.to.equal('Welcome to Your Vue.js App'){{/if_eq}}{{#if_eq runner "jest"}}.toEqual('Welcome to Your Vue.js App'){{/if_eq}}
+  })
+})

--- a/utils/index.js
+++ b/utils/index.js
@@ -28,10 +28,10 @@ exports.sortDependencies = function sortDependencies(data) {
  * @param {string} cwd Path of the created project directory
  * @param {object} data Data from questionnaire
  */
-exports.installDependencies = function installDependencies(cwd, color) {
+exports.installDependencies = function installDependencies(cwd, executable = 'npm', color) {
   console.log(`\n\n# ${color('Installing project dependencies ...')}`)
   console.log('# ========================\n')
-  return runCommand('npm', ['install'], {
+  return runCommand(executable, ['install'], {
     cwd
   })
 }

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,72 @@
+const path = require('path')
+const fs = require('fs')
+const spawn = require('child_process').spawn
+
+function sortObject(object) {
+  // Based on https://github.com/yarnpkg/yarn/blob/v1.3.2/src/config.js#L79-L85
+  const sortedObject = {};
+  Object.keys(object).sort().forEach(item => {
+    sortedObject[item] = object[item];
+  });
+  return sortedObject;
+}
+
+exports.sortDependencies = function sortDependencies(data) {
+  const packageJsonFile = path.join(
+    data.inPlace ? "" : data.destDirName,
+    "package.json"
+  )
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonFile))
+  packageJson.devDependencies = sortObject(packageJson.devDependencies)
+  packageJson.dependencies = sortObject(packageJson.dependencies)
+  fs.writeFileSync(
+    packageJsonFile,
+    JSON.stringify(packageJson, null, 2) + "\n"
+  );
+}
+
+exports.installDependencies = function installDependencies(cwd, data) {
+  console.log('\n\n# Installing project dependencies ...')
+  console.log('# ============\n')
+  return runCommand('npm', ['install'], {
+    cwd
+  })
+}
+
+exports.runLintFix = function runLintFix(cwd, data) {
+  if (data.lint && data.lintConfig === 'airbnb') {
+    console.log('\n\n# Running eslint --fix to comply with AirBnB preset rules...')
+    console.log(# '============\n')
+    return runCommand('npm', ['run', 'lint', '--', '--fix'], {
+      cwd
+    })
+  }
+  return Promise.resolve()
+}
+
+exports.printMessage = function printMessage(data) {
+  const message = `
+# Project initialization finished!
+# ============ 
+
+To get started:
+
+  ${data.inPlace ? '' : `cd ${data.destDirName}\n  `}npm run dev
+  
+Documentation can be found at https://vuejs-templates.github.io/webpack
+`
+  console.log(message)
+}
+
+function runCommand(cmd, args, options) {
+  return new Promise((resolve, reject) => {
+    const spwan = spawn(cmd, args, Object.assign({
+      cwd: process.cwd(),
+      stdio: 'inherit',
+    }, options))
+
+    spwan.on('exit', () => {
+      resolve()
+    })
+  })
+}

--- a/utils/index.js
+++ b/utils/index.js
@@ -28,8 +28,8 @@ exports.sortDependencies = function sortDependencies(data) {
  * @param {string} cwd Path of the created project directory
  * @param {object} data Data from questionnaire
  */
-exports.installDependencies = function installDependencies(cwd, data) {
-  console.log(`\n\n# Installing project dependencies ...`)
+exports.installDependencies = function installDependencies(cwd, color) {
+  console.log(`\n\n# ${color('Installing project dependencies ...')}`)
   console.log('# ========================\n')
   return runCommand('npm', ['install'], {
     cwd
@@ -41,9 +41,9 @@ exports.installDependencies = function installDependencies(cwd, data) {
  * @param {string} cwd Path of the created project directory
  * @param {object} data Data from questionnaire
  */
-exports.runLintFix = function runLintFix(cwd, data) {
+exports.runLintFix = function runLintFix(cwd, data, color) {
   if (data.lint && lintStyles.indexOf(data.lintConfig) !== -1) {
-    console.log(`\n\nRunning eslint --fix to comply with AirBnB preset rules...`)
+    console.log(`\n\n${color('Running eslint --fix to comply with AirBnB preset rules...')}`)
     console.log('# ========================\n')
     return runCommand('npm', ['run', 'lint', '--', '--fix'], {
       cwd
@@ -56,14 +56,14 @@ exports.runLintFix = function runLintFix(cwd, data) {
  * Prints the final message with instructions of necessary next steps.
  * @param {Object} data Data from questionnaire.
  */
-exports.printMessage = function printMessage(data) {
+exports.printMessage = function printMessage(data, { green, yellow }) {
   const message = `
-# Project initialization finished!
+# ${green('Project initialization finished!')}
 # ========================
 
 To get started:
 
-  ${data.inPlace ? '' : `cd ${data.destDirName}\n  `}${requiresLint(data) ? 'npm run lint -- --fix\n  ' : ''}npm run dev
+  ${yellow(`${data.inPlace ? '' : `cd ${data.destDirName}\n  `}${requiresLint(data) ? 'npm run lint -- --fix\n  ' : ''}npm run dev`)}
   
 Documentation can be found at https://vuejs-templates.github.io/webpack
 `

--- a/utils/index.js
+++ b/utils/index.js
@@ -36,7 +36,7 @@ exports.installDependencies = function installDependencies(cwd, data) {
 exports.runLintFix = function runLintFix(cwd, data) {
   if (data.lint && data.lintConfig === 'airbnb') {
     console.log('\n\n# Running eslint --fix to comply with AirBnB preset rules...')
-    console.log(# '============\n')
+    console.log('# ============\n')
     return runCommand('npm', ['run', 'lint', '--', '--fix'], {
       cwd
     })

--- a/utils/index.js
+++ b/utils/index.js
@@ -43,7 +43,7 @@ exports.installDependencies = function installDependencies(cwd, executable = 'np
  */
 exports.runLintFix = function runLintFix(cwd, data, color) {
   if (data.lint && lintStyles.indexOf(data.lintConfig) !== -1) {
-    console.log(`\n\n${color('Running eslint --fix to comply with AirBnB preset rules...')}`)
+    console.log(`\n\n${color('Running eslint --fix to comply with chosen preset rules...')}`)
     console.log('# ========================\n')
     return runCommand('npm', ['run', 'lint', '--', '--fix'], {
       cwd

--- a/utils/index.js
+++ b/utils/index.js
@@ -2,15 +2,13 @@ const path = require('path')
 const fs = require('fs')
 const spawn = require('child_process').spawn
 
-function sortObject(object) {
-  // Based on https://github.com/yarnpkg/yarn/blob/v1.3.2/src/config.js#L79-L85
-  const sortedObject = {};
-  Object.keys(object).sort().forEach(item => {
-    sortedObject[item] = object[item];
-  });
-  return sortedObject;
-}
+const lintStyles = ['standard', 'airbnb']
 
+/**
+ * Sorts dependencies in package.json alphabetically.
+ * They are unsorted because they were grouped for the handlebars helpers
+ * @param {object} data Data from questionnaire
+ */
 exports.sortDependencies = function sortDependencies(data) {
   const packageJsonFile = path.join(
     data.inPlace ? "" : data.destDirName,
@@ -25,18 +23,28 @@ exports.sortDependencies = function sortDependencies(data) {
   );
 }
 
+/**
+ * Runs `npm install` in the project directory
+ * @param {string} cwd Path of the created project directory
+ * @param {object} data Data from questionnaire
+ */
 exports.installDependencies = function installDependencies(cwd, data) {
-  console.log('\n\n# Installing project dependencies ...')
-  console.log('# ============\n')
+  console.log(`\n\n# Installing project dependencies ...`)
+  console.log('# ========================\n')
   return runCommand('npm', ['install'], {
     cwd
   })
 }
 
+/**
+ * Runs `npm run lint -- --fix` in the project directory
+ * @param {string} cwd Path of the created project directory
+ * @param {object} data Data from questionnaire
+ */
 exports.runLintFix = function runLintFix(cwd, data) {
-  if (data.lint && data.lintConfig === 'airbnb') {
-    console.log('\n\n# Running eslint --fix to comply with AirBnB preset rules...')
-    console.log('# ============\n')
+  if (data.lint && lintStyles.indexOf(data.lintConfig) !== -1) {
+    console.log(`\n\nRunning eslint --fix to comply with AirBnB preset rules...`)
+    console.log('# ========================\n')
     return runCommand('npm', ['run', 'lint', '--', '--fix'], {
       cwd
     })
@@ -44,20 +52,40 @@ exports.runLintFix = function runLintFix(cwd, data) {
   return Promise.resolve()
 }
 
+/**
+ * Prints the final message with instructions of necessary next steps.
+ * @param {Object} data Data from questionnaire.
+ */
 exports.printMessage = function printMessage(data) {
   const message = `
 # Project initialization finished!
-# ============ 
+# ========================
 
 To get started:
 
-  ${data.inPlace ? '' : `cd ${data.destDirName}\n  `}npm run dev
+  ${data.inPlace ? '' : `cd ${data.destDirName}\n  `}${requiresLint(data) ? 'npm run lint -- --fix\n  ' : ''}npm run dev
   
 Documentation can be found at https://vuejs-templates.github.io/webpack
 `
   console.log(message)
 }
 
+/**
+ * Returns true if the user will have to run lint --fix themselves.
+ * @param {Object} data Data from questionnaire.
+ */
+function requiresLint(data) {
+  return !data.autoInstall && data.lint && lintStyles.indexOf(data.lintConfig) !== -1
+}
+
+/**
+ * Spawns a child process and runs the specified command
+ * By default, runs in the CWD and inherits stdio
+ * Options are the same as node's child_process.spawn
+ * @param {string} cmd 
+ * @param {array<string>} args 
+ * @param {object} options
+ */
 function runCommand(cmd, args, options) {
   return new Promise((resolve, reject) => {
     const spwan = spawn(cmd, args, Object.assign({
@@ -69,4 +97,13 @@ function runCommand(cmd, args, options) {
       resolve()
     })
   })
+}
+
+function sortObject(object) {
+  // Based on https://github.com/yarnpkg/yarn/blob/v1.3.2/src/config.js#L79-L85
+  const sortedObject = {};
+  Object.keys(object).sort().forEach(item => {
+    sortedObject[item] = object[item];
+  });
+  return sortedObject;
 }


### PR DESCRIPTION
## What this PR does

* runs `npm install`for you after you answered all the questions
* run `npm run lint -- --fix` to adjust the boilerplate code to the selected eslint config


This allows us to get rid of the ugly template strings we currently use to cater towards airbnb style, like this:
```handlebars
{{#if_eq lintConfig "airbnb"}},{{/if_eq}}
```

These make the template source files barely readable in places. Getting rid of them increases maintainability

## TODO

- [x] run `npm install` after the project directory has been set up.
- [x] run `npm run lint -- --fix` if airbnb preset was selected for eslint
- [x] Make auto-install optional through a question in the init questionnaire
- [x] If user chose `standard` or `airbnb` style and chose not to auto-install dependencies, we can't run lint-fix for him. In that case, print a not to run it themselves in the final console message.
- [x] Improve console messages with chalk
- [x] Let user choose between npm and yarn 

## How can you help?

Take this for a spin. I surely have made a few minor mistakes, like typos in the new console messages, and maybe you find a big one as well.

In particular, **testing it on windows** would be very helpful. 

If you find anything, just send a PR against this branch.

