### PR TITLE
webpack.test.conf.js is not needed in jest and e2e

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -117,7 +117,7 @@ module.exports = {
     ".eslintrc.js": "lint",
     ".eslintignore": "lint",
     "config/test.env.js": "unit || e2e",
-    "build/webpack.test.conf.js": "e2e || (unit && runner === 'karma')",
+    "build/webpack.test.conf.js": "unit && runner === 'karma'",
     "test/unit/**/*": "unit",
     "test/unit/index.js": "unit && runner === 'karma'",
     "test/unit/jest.conf.js": "unit && runner === 'jest'",


### PR DESCRIPTION
As titled.