### PR TITLE
remove eventsource-polyfill

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -94,7 +94,6 @@
     "chalk": "^2.0.1",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.28.0",
-    "eventsource-polyfill": "^0.9.6",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^1.1.4",
     "friendly-errors-webpack-plugin": "^1.6.1",


### PR DESCRIPTION
now use `webpack-dev-server`, it base on `socket`,  so l think  there is no necessary need  `eventsource-polyfill`  anymore.