### PR TITLE
Set spawn opt shell as true to avoid ENOENT

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -122,6 +122,7 @@ function runCommand(cmd, args, options) {
         {
           cwd: process.cwd(),
           stdio: 'inherit',
+          shell: true,
         },
         options
       )


### PR DESCRIPTION
This adds the option `shell: true` to the `spawn` invocation. We had identified and fixed this in https://github.com/vuejs-templates/webpack/pull/1133#discussion_r155466442 but the change might have been lost during a merge/rebase. The change is not present in the squash-merge commit [`ecd68c4`](https://github.com/vuejs-templates/webpack/commit/ecd68c4b72c0282bff1cd291ff9f91e30ce27d22#diff-8d6b1f9270334e293ad1f2ddec84e050R91). This change _should_ fix it for everyone.

Related issue - vuejs/vue-cli#681.
Closes #1168.