### PR TITLE
Handle npm install error gracefully

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -155,9 +155,9 @@ module.exports = {
     const cwd = path.join(process.cwd(), data.inPlace ? '' : data.destDirName)
 
     if (data.autoInstall) {
-      installDependencies(cwd, data.autoInstall, green)
+      installDependencies(cwd, data.autoInstall, chalk)
         .then(() => {
-          return runLintFix(cwd, data, green)
+          return runLintFix(cwd, data, chalk)
         })
         .then(() => {
           printMessage(data, green)

--- a/meta.js
+++ b/meta.js
@@ -155,7 +155,7 @@ module.exports = {
     const cwd = path.join(process.cwd(), data.inPlace ? '' : data.destDirName)
 
     if (data.autoInstall) {
-      installDependencies(cwd, data.autoInstall, chalk)
+      installDependencies(cwd, data, chalk)
         .then(() => {
           return runLintFix(cwd, data, chalk)
         })
@@ -163,7 +163,8 @@ module.exports = {
           printMessage(data, green)
         })
         .catch(e => {
-          console.log(chalk.red('Error:'), e)
+          console.log(e.name)
+          console.log(e.message)
         })
     } else {
       printMessage(data, chalk)

--- a/utils/index.js
+++ b/utils/index.js
@@ -125,7 +125,7 @@ function installMsg(data) {
  */
 function runCommand(cmd, args, options) {
   return new Promise((resolve, reject) => {
-    const spwan = spawn(
+    const child = spawn(
       cmd,
       args,
       Object.assign(
@@ -138,8 +138,12 @@ function runCommand(cmd, args, options) {
       )
     )
 
-    spwan.on('exit', () => {
+    child.on('exit', () => {
       resolve()
+    })
+
+    child.on('error', error => {
+      reject(error)
     })
   })
 }

--- a/utils/index.js
+++ b/utils/index.js
@@ -28,12 +28,22 @@ exports.sortDependencies = function sortDependencies(data) {
 exports.installDependencies = function installDependencies(
   cwd,
   executable = 'npm',
-  color
+  chalk
 ) {
-  console.log(`\n\n# ${color('Installing project dependencies ...')}`)
+  console.log(`\n\n# ${chalk.green('Installing project dependencies ...')}`)
   console.log('# ========================\n')
   return runCommand(executable, ['install'], {
     cwd,
+  })
+  .catch(error => {
+    console.error(error)
+    console.log('# ' + chalk.red('Error installing dependencies\n'))
+    console.log(`Don't worry though, your project is still totally fine,
+we just had problems running \`npm install\` for you. 
+So run these commands in your project directory and you will be fine:
+  ${chalk.yellow('npm install')} (or for yarn: ${chalk.yellow('yarn')})
+  ${chalk.yellow('npm run lint -- --fix')} (or for yarn: ${chalk.yellow('yarn lint --fix')})
+    `)
   })
 }
 
@@ -42,10 +52,10 @@ exports.installDependencies = function installDependencies(
  * @param {string} cwd Path of the created project directory
  * @param {object} data Data from questionnaire
  */
-exports.runLintFix = function runLintFix(cwd, data, color) {
+exports.runLintFix = function runLintFix(cwd, data, chalk) {
   if (data.lint && lintStyles.indexOf(data.lintConfig) !== -1) {
     console.log(
-      `\n\n${color(
+      `\n\n${chalk.green(
         'Running eslint --fix to comply with chosen preset rules...'
       )}`
     )


### PR DESCRIPTION
### The problem

See #1168 - it ssems to be fixed by #1170 already, but imrpoving the error handling in case something breaks might still be a good idea.

Thougths?

### What does this PR add/change?

When the user has chosen to let the template automatically install dependencies, and that call to `npm install` fails, We now display a usefull error message with instructions on how to proceed.


![bildschirmfoto 2017-12-14 um 12 57 04](https://user-images.githubusercontent.com/1444526/33991274-4cb82fa6-e0ce-11e7-8f69-97693034a41e.png)

### Is that a perfect solution?

Not really, but it helps to proceed even if autoInstall fails.

If someone for whom this process fails would be willing to investigate, that would be much apprechiated. Since I can't reproduce the error from #1168, I don't know how to debug this.

### To test this PR:

```
vue init webpack#fix_installerror_1168 
```

Thanks!