### PR TITLE
Fix: syntax for airbnb eslint

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.yarn-cache/
 node_modules/
 /dist/
 npm-debug.log*

--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -11,15 +11,15 @@
 
 <script>
 {{#unless router}}
-import HelloWorld from './components/HelloWorld'
+import HelloWorld from './components/HelloWorld';
 
 {{/unless}}
 export default {
-  name: 'app'{{#router}}{{else}},
+  name: 'app',{{#router}}{{else}}
   components: {
-    HelloWorld
-  }{{/router}}
-}
+    HelloWorld,
+  },{{/router}}
+};
 </script>
 
 <style>

--- a/template/src/components/HelloWorld.vue
+++ b/template/src/components/HelloWorld.vue
@@ -23,12 +23,12 @@
 <script>
 export default {
   name: 'HelloWorld',
-  data () {
+  data() {
     return {
-      msg: 'Welcome to Your Vue.js App'
-    }
-  }
-}
+      msg: 'Welcome to Your Vue.js App',
+    };
+  },
+};
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -2,13 +2,13 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 {{/if_eq}}
-import Vue from 'vue'
-import App from './App'
+import Vue from 'vue';
+import App from './App';
 {{#router}}
-import router from './router'
+import router from './router';
 {{/router}}
 
-Vue.config.productionTip = false
+Vue.config.productionTip = false;
 
 /* eslint-disable no-new */
 new Vue({
@@ -17,10 +17,10 @@ new Vue({
   router,
   {{/router}}
   {{#if_eq build "runtime"}}
-  render: h => h(App)
+  render: h => h(App),
   {{/if_eq}}
   {{#if_eq build "standalone"}}
   template: '<App/>',
-  components: { App }
+  components: { App },
   {{/if_eq}}
-})
+});

--- a/template/src/router/index.js
+++ b/template/src/router/index.js
@@ -1,15 +1,15 @@
-import Vue from 'vue'
-import Router from 'vue-router'
-import HelloWorld from '@/components/HelloWorld'
+import Vue from 'vue';
+import Router from 'vue-router';
+import HelloWorld from '@/components/HelloWorld';
 
-Vue.use(Router)
+Vue.use(Router);
 
 export default new Router({
   routes: [
     {
       path: '/',
       name: 'HelloWorld',
-      component: HelloWorld
-    }
-  ]
-})
+      component: HelloWorld,
+    },
+  ],
+});

--- a/template/test/e2e/specs/test.js
+++ b/template/test/e2e/specs/test.js
@@ -6,7 +6,7 @@ module.exports = {
     // automatically uses dev Server port from /config.index.js
     // default: http://localhost:8080
     // see nightwatch.conf.js
-    const devServer = browser.globals.devServerURL
+    const devServer = browser.globals.devServerURL;
 
     browser
       .url(devServer)
@@ -14,6 +14,6 @@ module.exports = {
       .assert.elementPresent('.hello')
       .assert.containsText('h1', 'Welcome to Your Vue.js App')
       .assert.elementCount('img', 1)
-      .end()
-  }
-}
+      .end();
+  },
+};

--- a/template/test/unit/specs/HelloWorld.spec.js
+++ b/template/test/unit/specs/HelloWorld.spec.js
@@ -1,11 +1,11 @@
-import Vue from 'vue'
-import HelloWorld from '@/components/HelloWorld'
+import Vue from 'vue';
+import HelloWorld from '@/components/HelloWorld';
 
 describe('HelloWorld.vue', () => {
   it('should render correct contents', () => {
-    const Constructor = Vue.extend(HelloWorld)
-    const vm = new Constructor().$mount()
+    const Constructor = Vue.extend(HelloWorld);
+    const vm = new Constructor().$mount();
     expect(vm.$el.querySelector('.hello h1').textContent)
-    {{#if_eq runner "karma"}}.to.equal('Welcome to Your Vue.js App'){{/if_eq}}{{#if_eq runner "jest"}}.toEqual('Welcome to Your Vue.js App'){{/if_eq}}
-  })
-})
+    {{#if_eq runner "karma"}}.to.equal('Welcome to Your Vue.js App'){{/if_eq}}{{#if_eq runner "jest"}}.toEqual('Welcome to Your Vue.js App'){{/if_eq}};
+  });
+});


### PR DESCRIPTION
I chose airbnb eslint preset and got these errors:

> src/App.vue
>   10:14  error  Missing trailing comma  comma-dangle
>   11:2   error  Missing semicolon       semi
> 
> src/components/HelloWorld.vue
>   26:7   error  Unexpected space before function parentheses  space-before-function-paren
>   28:40  error  Missing trailing comma                        comma-dangle
>   29:6   error  Missing semicolon                             semi
>   30:4   error  Missing trailing comma                        comma-dangle
>   31:2   error  Missing semicolon                             semi
> 
> src/main.js
>    3:22  error  Missing semicolon       semi
>    4:24  error  Missing semicolon       semi
>    5:30  error  Missing semicolon       semi
>    7:33  error  Missing semicolon       semi
>   14:22  error  Missing trailing comma  comma-dangle
>   15:3   error  Missing semicolon       semi
> 
> src/router/index.js
>    1:22  error  Missing semicolon       semi
>    2:32  error  Missing semicolon       semi
>    3:49  error  Missing semicolon       semi
>    5:16  error  Missing semicolon       semi
>   12:28  error  Missing trailing comma  comma-dangle
>   13:6   error  Missing trailing comma  comma-dangle
>   14:4   error  Missing trailing comma  comma-dangle
>   15:3   error  Missing semicolon       semi
> 
> test/unit/specs/HelloWorld.spec.js
>    1:22  error  Missing semicolon  semi
>    2:49  error  Missing semicolon  semi
>    6:47  error  Missing semicolon  semi
>    7:42  error  Missing semicolon  semi
>    9:43  error  Missing semicolon  semi
>   10:5   error  Missing semicolon  semi
>   11:3   error  Missing semicolon  semi
> 
> test/e2e/specs/test.js
>    9:51  error  Missing semicolon       semi
>   17:13  error  Missing semicolon       semi
>   18:4   error  Missing trailing comma  comma-dangle
>   19:2   error  Missing semicolon       semi
> 
> ✖ 32 problems (32 errors, 0 warnings)

This PR will fix the style of the template for preventing this in the future.

I also suggest to add .yarn-cache to .gitignore in this PR. There is no problem if you still use npm instead of yarn, but will cause a nuisance on commit for yarn users. Npm users could remove it painlessly later.

I recommend to add an issue for test.sh rework because it tests the only standard options while need to test all of it.