### PR TITLE
Load, render template version using helper

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -6,16 +6,22 @@ const {
   runLintFix,
   printMessage,
 } = require('./utils')
+const pkg = require('./package.json')
+
+const templateVersion = pkg.version
 
 module.exports = {
   helpers: {
-    if_or: function(v1, v2, options) {
+    if_or(v1, v2, options) {
       if (v1 || v2) {
         return options.fn(this)
       }
 
       return options.inverse(this)
     },
+  },
+  template_version() {
+    return templateVersion
   },
   prompts: {
     name: {

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -1,5 +1,5 @@
 'use strict'
-// Template version: 1.2.7
+// Template version: {{ template_version }}
 // see http://vuejs-templates.github.io/webpack for documentation.
 
 const path = require('path')


### PR DESCRIPTION
This adds a helper to `meta.js` so that the template version in `template/config/index.js` does not need manual maintenance and is instead loaded from `package.json>version`. 