### PR TITLE
Change engine>node{4 => 6} for template

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -118,7 +118,7 @@
     "webpack-merge": "^4.1.0"
   },
   "engines": {
-    "node": ">= 4.0.0",
+    "node": ">= 6.0.0",
     "npm": ">= 3.0.0"
   },
   "browserslist": [


### PR DESCRIPTION
The template is no longer compatible with node 4. This updates the `engines>node` field in the template `package.json` to indicate the minimum required version.