### PR TITLE
Add HardSourceWebpackPlugin to improve compiling time

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -3,6 +3,7 @@ const path = require('path')
 const utils = require('./utils')
 const config = require('../config')
 const vueLoaderConfig = require('./vue-loader.conf')
+const HardSourceWebpackPlugin = require('hard-source-webpack-plugin')
 
 function resolve (dir) {
   return path.join(__dirname, '..', dir)
@@ -24,6 +25,9 @@ module.exports = {
   entry: {
     app: './src/main.js'
   },
+  plugins: [
+    new HardSourceWebpackPlugin()
+  ],
   output: {
     path: config.build.assetsRoot,
     filename: '[name].js',

--- a/template/package.json
+++ b/template/package.json
@@ -97,6 +97,7 @@
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^1.1.4",
     "friendly-errors-webpack-plugin": "^1.6.1",
+    "hard-source-webpack-plugin": "^0.5.14",
     "html-webpack-plugin": "^2.30.1",
     "webpack-bundle-analyzer": "^2.9.0",
     "node-notifier": "^5.1.2",


### PR DESCRIPTION
**Problem**
Running dev server with `npm run dev` takes about 40s to compile, each time. Same thing with production builds.

**Solution**
Using HardSourceWebpackPlugin improves caching. Therefore launching dev server first time takes 40s, launching it second time takes 1s.

Source:
https://medium.com/ottofellercom/0-100-in-two-seconds-speed-up-webpack-465de691ed4a
  