### PR TITLE
Typo, whitespace and Style Guide fixes

### DIFF
--- a/template/build/build.js
+++ b/template/build/build.js
@@ -22,7 +22,7 @@ rm(path.join(config.build.assetsRoot, config.build.assetsSubDirectory), err => {
     process.stdout.write(stats.toString({
       colors: true,
       modules: false,
-      children: false, // if you are using ts-loader, setting this to true will make tyescript errors show up during build
+      children: false, // if you are using ts-loader, setting this to true will make typescript errors show up during build
       chunks: false,
       chunkModules: false
     }) + '\n\n')

--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -15,7 +15,7 @@ import HelloWorld from './components/HelloWorld'
 
 {{/unless}}
 export default {
-  name: 'app'{{#router}}{{else}},
+  name: 'App'{{#router}}{{else}},
   components: {
     HelloWorld
   }{{/router}}

--- a/template/src/components/HelloWorld.vue
+++ b/template/src/components/HelloWorld.vue
@@ -3,19 +3,82 @@
     <h1>\{{ msg }}</h1>
     <h2>Essential Links</h2>
     <ul>
-      <li><a href="https://vuejs.org" target="_blank">Core Docs</a></li>
-      <li><a href="https://forum.vuejs.org" target="_blank">Forum</a></li>
-      <li><a href="https://chat.vuejs.org" target="_blank">Community Chat</a></li>
-      <li><a href="https://twitter.com/vuejs" target="_blank">Twitter</a></li>
+      <li>
+        <a
+          href="https://vuejs.org"
+          target="_blank"
+        >
+          Core Docs
+        </a>
+      </li>
+      <li>
+        <a
+          href="https://forum.vuejs.org"
+          target="_blank"
+        >
+          Forum
+        </a>
+      </li>
+      <li>
+        <a
+          href="https://chat.vuejs.org"
+          target="_blank"
+        >
+          Community Chat
+        </a>
+      </li>
+      <li>
+        <a
+          href="https://twitter.com/vuejs"
+          target="_blank"
+        >
+          Twitter
+        </a>
+      </li>
       <br>
-      <li><a href="http://vuejs-templates.github.io/webpack/" target="_blank">Docs for This Template</a></li>
+      <li>
+        <a
+          href="http://vuejs-templates.github.io/webpack/"
+          target="_blank"
+        >
+          Docs for This Template
+        </a>
+      </li>
     </ul>
     <h2>Ecosystem</h2>
     <ul>
-      <li><a href="http://router.vuejs.org/" target="_blank">vue-router</a></li>
-      <li><a href="http://vuex.vuejs.org/" target="_blank">vuex</a></li>
-      <li><a href="http://vue-loader.vuejs.org/" target="_blank">vue-loader</a></li>
-      <li><a href="https://github.com/vuejs/awesome-vue" target="_blank">awesome-vue</a></li>
+      <li>
+        <a
+          href="http://router.vuejs.org/"
+          target="_blank"
+        >
+          vue-router
+        </a>
+      </li>
+      <li>
+        <a
+          href="http://vuex.vuejs.org/"
+          target="_blank"
+        >
+          vuex
+        </a>
+      </li>
+      <li>
+        <a
+          href="http://vue-loader.vuejs.org/"
+          target="_blank"
+        >
+          vue-loader
+        </a>
+      </li>
+      <li>
+        <a
+          href="https://github.com/vuejs/awesome-vue"
+          target="_blank"
+        >
+          awesome-vue
+        </a>
+      </li>
     </ul>
   </div>
 </template>

--- a/template/test/unit/specs/HelloWorld.spec.js
+++ b/template/test/unit/specs/HelloWorld.spec.js
@@ -6,6 +6,6 @@ describe('HelloWorld.vue', () => {
     const Constructor = Vue.extend(HelloWorld)
     const vm = new Constructor().$mount()
     expect(vm.$el.querySelector('.hello h1').textContent)
-    {{#if_eq runner "karma"}}.to.equal('Welcome to Your Vue.js App'){{/if_eq}}{{#if_eq runner "jest"}}.toEqual('Welcome to Your Vue.js App'){{/if_eq}}
+      {{#if_eq runner "karma"}}.to.equal('Welcome to Your Vue.js App'){{/if_eq}}{{#if_eq runner "jest"}}.toEqual('Welcome to Your Vue.js App'){{/if_eq}}
   })
 })


### PR DESCRIPTION
I've fixed 3 small code style issues:
1. Comment typo in word in file `/build/build.js`: `tyescript` -> `typescript`
2. Jest JS example test formatting got a bit more traditional:
```js
expect( ... )
.toEqual( ... )
```
->
```js
expect( ... )
  .toEqual( ... )
```
3. Style Guide [Strongly Recommended Rule](https://vuejs.org/v2/style-guide/#Component-name-casing-in-templates-strongly-recommended) violated in `src/App.vue`.

`App` component should declare itself as `name: 'App'` instead of `name: 'app'`.
I've found this error by applying ESLint 'plugin:vue/recommended'.

4. Style Guide [Strongly Recommended Rule](https://vuejs.org/v2/style-guide/#Multi-attribute-elements-strongly-recommended) violation fixed in `src/components/HelloWorld.vue`.
Each `<a>` link was placed fully in a single line for the sake of simplicity.
Style Guide suggests splitting elements with several attributes over several lines.
Old version:
```html
<li><a href="https://vuejs.org" target="_blank">Core Docs</a></li>
```
`Vue`-styled version:
```html
<li>
  <a
    href="https://vuejs.org"
    target="_blank"
  >
    Core Docs
  </a>
</li>
```
I've found this error by applying ESLint 'plugin:vue/recommended'.
  