### PR TITLE
Mapped config.dev.https to devWebpackConfig.devServer (#1217)

### DIFF
--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -31,6 +31,7 @@ const devWebpackConfig = merge(baseWebpackConfig, {
     hot: true,
     contentBase: false, // since we use CopyWebpackPlugin.
     compress: true,
+    https: config.dev.https,
     host: HOST || config.dev.host,
     port: PORT || config.dev.port,
     open: config.dev.autoOpenBrowser,
@@ -78,11 +79,13 @@ module.exports = new Promise((resolve, reject) => {
       process.env.PORT = port
       // add port to devServer config
       devWebpackConfig.devServer.port = port
+      // which protocol to show in notifications
+      const protocol = devWebpackConfig.devServer.https ? 'https': 'http';
 
       // Add FriendlyErrorsPlugin
       devWebpackConfig.plugins.push(new FriendlyErrorsPlugin({
         compilationSuccessInfo: {
-          messages: [`Your application is running here: http://${devWebpackConfig.devServer.host}:${port}`],
+          messages: [`Your application is running here: ${protocol}://${devWebpackConfig.devServer.host}:${port}`],
         },
         onErrors: config.dev.notifyOnErrors
         ? utils.createNotifierCallback()


### PR DESCRIPTION
@LinusBorg 
The changes are similar as described at https://github.com/vuejs-templates/webpack/issues/1217, with the addition that in the notification message http|https are show as appropriate.

It took me a while to realize I had to $ vue init bird-cage/webpack **#dev** (I'm new to this ;-), but then it worked as expected.

What do you think?

What I also see, but can't figure out how to improve (assuming you would see this as an enhancement) is if for example the port is set in package.json scripts dev: .... --port 8181 the dev server will use this port instead of that in config/index.js, but the notification message still reads ...:8080 or whatever is set in config/index.js