### PR TITLE
Docs: formatting/typo fixes

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -42,10 +42,10 @@ So, the environment variables are:
 
 As we can see, `test.env` inherits the `dev.env` and the `dev.env` inherits the `prod.env`.
 
-### Usage		
+### Usage
 
-It is simple to use the environment variables in your code. For example:		
+It is simple to use the environment variables in your code. For example:
 
-```js		
-Vue.config.productionTip = process.env.NODE_ENV === 'production'		
+```js
+Vue.config.productionTip = process.env.NODE_ENV === 'production'
 ```

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -31,5 +31,5 @@ You can run the following command to let eslint fix any errors it finds (if it c
 npm run lint -- --fix
 ```
 
-*(The `--` in the middle is necessary to ensure the `--fix` option is passdd to `eslint`, not to `npm`. It can be omitted whne using yarn)*
+*(The `--` in the middle is necessary to ensure the `--fix` option is passed to `eslint`, not to `npm`. It can be omitted when using yarn)*
 

--- a/docs/pre-processors.md
+++ b/docs/pre-processors.md
@@ -1,6 +1,6 @@
 # Pre-Processors
 
-This boilerplate has pre-configured CSS extraction for most popular CSS pre-processors including LESS, SASS, Stylus, and PostCSS. To use a pre-processor, all you need to do is install the appropriate webpack loader for it. For example, to use SASS:
+This boilerplate has pre-configured CSS extraction for most popular CSS pre-processors including LESS, Sass, Stylus, and PostCSS. To use a pre-processor, all you need to do is install the appropriate webpack loader for it. For example, to use Sass:
 
 ``` bash
 npm install sass-loader node-sass --save-dev
@@ -14,11 +14,11 @@ Once installed, you can use the pre-processors inside your `*.vue` components us
 
 ``` html
 <style lang="scss">
-/* write SASS! */
+/* write Sass! */
 </style>
 ```
 
-### A note on SASS syntax
+### A note on Sass syntax
 
 - `lang="scss"` corresponds to the CSS-superset syntax (with curly braces and semicolons).
 - `lang="sass"` corresponds to the indentation-based syntax.
@@ -27,7 +27,7 @@ Once installed, you can use the pre-processors inside your `*.vue` components us
 
 Styles in `*.vue` files and style files (`*.css`, `*.scss` etc) are piped through PostCSS by default, so you don't need to use a specific loader for it.
 
-You can simply add PostCSS plugins you want to use to the `.postcssrc.js`file in your project's root directory:
+You can simply add PostCSS plugins you want to use to the `.postcssrc.js` file in your project's root directory:
 
 ``` js
 // https://github.com/michael-ciniawsky/postcss-load-config


### PR DESCRIPTION
Minor fixes for two typos and some trailing whitespace, plus [`Sass` instead of `SASS`](https://sass-lang.com/).