### PR TITLE
Optimize CI/Test recognition in meta.js

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -46,7 +46,7 @@ module.exports = {
       message: 'Author',
       when: 'false'
     }
-  } : {
+  } : { // The "real" prompts begin here
     name: {
       type: 'string',
       required: true,

--- a/meta.js
+++ b/meta.js
@@ -33,8 +33,20 @@ module.exports = {
     },
   },
   
-  // We don'T add prompts if this is running in a test
-  prompts: isTest ? undefined : {
+  // We don't add prompts if this is running in a test
+  prompts: isTest 
+    ? { // This dummy object is necessary to skpi vue-cli prompt defaults for name and author
+    name: {
+      type: 'string',
+      message: 'Name',
+      when: 'false'
+    },
+    author: {
+      type: 'string',
+      message: 'Author',
+      when: 'false'
+    }
+  } : {
     name: {
       type: 'string',
       required: true,

--- a/meta.js
+++ b/meta.js
@@ -7,11 +7,12 @@ const {
   runLintFix,
   printMessage,
 } = require('./utils')
+
 const pkg = require('./package.json')
 
 const templateVersion = pkg.version
 
-const { addTestAnswers } = require('./scenarios')
+const { addTestAnswers, isTest } = require('./scenarios')
 
 module.exports = {
   metalsmith: {
@@ -32,27 +33,24 @@ module.exports = {
     },
   },
   
-  prompts: {
+  // We don'T add prompts if this is running in a test
+  prompts: isTest ? undefined : {
     name: {
-      when: 'isNotTest',
       type: 'string',
       required: true,
       message: 'Project name',
     },
     description: {
-      when: 'isNotTest',
       type: 'string',
       required: false,
       message: 'Project description',
       default: 'A Vue.js project',
     },
     author: {
-      when: 'isNotTest',
       type: 'string',
       message: 'Author',
     },
     build: {
-      when: 'isNotTest',
       type: 'list',
       message: 'Vue build',
       choices: [
@@ -70,17 +68,15 @@ module.exports = {
       ],
     },
     router: {
-      when: 'isNotTest',
       type: 'confirm',
       message: 'Install vue-router?',
     },
     lint: {
-      when: 'isNotTest',
       type: 'confirm',
       message: 'Use ESLint to lint your code?',
     },
     lintConfig: {
-      when: 'isNotTest && lint',
+      when: 'lint',
       type: 'list',
       message: 'Pick an ESLint preset',
       choices: [
@@ -102,12 +98,11 @@ module.exports = {
       ],
     },
     unit: {
-      when: 'isNotTest',
       type: 'confirm',
       message: 'Set up unit tests',
     },
     runner: {
-      when: 'isNotTest && unit',
+      when: 'unit',
       type: 'list',
       message: 'Pick a test runner',
       choices: [
@@ -129,12 +124,10 @@ module.exports = {
       ],
     },
     e2e: {
-      when: 'isNotTest',
       type: 'confirm',
       message: 'Setup e2e tests with Nightwatch?',
     },
     autoInstall: {
-      when: 'isNotTest',
       type: 'list',
       message:
         'Should we run `npm install` for you after the project has been created? (recommended)',


### PR DESCRIPTION
#1218 made some changes that allows us to test various scenarios of installs in CI, but it used a special condition for all prompts in `meta.js`, which was hacky and makes contributions harder.

This PR introduces a simple refacor that makes this condition unnecessary and therefore, cleans the prompts up.