### PR TITLE
Fixing babel-eslint >=8 not working with babel 6 (at least on Windows)

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     {{#lint}}
-    "babel-eslint": "^8.2.1",
+    "babel-eslint": "^7.2.3",
     "eslint": "^4.15.0",
     "eslint-friendly-formatter": "^3.0.0",
     "eslint-loader": "^1.7.1",


### PR DESCRIPTION
Downgraded babel-eslint to 7.x