### PR TITLE
Remove mapCoverage as it is deprecated

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -52,7 +52,7 @@
     "babel-jest": "^21.0.2",
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
-    "jest": "^22.0.4",
+    "jest": "^22.4.2",
     "jest-serializer-vue": "^0.3.0",
     "vue-jest": "^1.0.2",
     {{/if_eq}}

--- a/template/test/unit/jest.conf.js
+++ b/template/test/unit/jest.conf.js
@@ -19,7 +19,6 @@ module.exports = {
   ],{{/e2e}}
   snapshotSerializers: ['<rootDir>/node_modules/jest-serializer-vue'],
   setupFiles: ['<rootDir>/test/unit/setup'],
-  mapCoverage: true,
   coverageDirectory: '<rootDir>/test/unit/coverage',
   collectCoverageFrom: [
     'src/**/*.{js,vue}',


### PR DESCRIPTION
mapCoverage has been deprecated since Jest@22.4.0
https://github.com/facebook/jest/blob/master/CHANGELOG.md#2240
https://github.com/facebook/jest/pull/5177