### PR TITLE
chore: handle asset types in Jest

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -54,6 +54,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "jest": "^22.0.4",
     "jest-serializer-vue": "^0.3.0",
+    "jest-transform-stub": "^1.0.0",
     "vue-jest": "^1.0.2",
     {{/if_eq}}
     {{#if_eq runner "karma"}}

--- a/template/test/unit/jest.conf.js
+++ b/template/test/unit/jest.conf.js
@@ -12,7 +12,8 @@ module.exports = {
   },
   transform: {
     '^.+\\.js$': '<rootDir>/node_modules/babel-jest',
-    '.*\\.(vue)$': '<rootDir>/node_modules/vue-jest'
+    '.*\\.(vue)$': '<rootDir>/node_modules/vue-jest',
+    '.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub'
   },{{#e2e}}
   testPathIgnorePatterns: [
     '<rootDir>/test/e2e'


### PR DESCRIPTION
- Handle imports from different asset types. Uses a simple package I wrote to return an empty string when the file is imported—https://github.com/eddyerburgh/jest-transform-stub/blob/master/index.js


Closes #1317