### PR TITLE
Switch dev run script message depending on user selection (npm/yarn)

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -66,6 +66,8 @@ exports.runLintFix = function runLintFix(cwd, data, color) {
  * @param {Object} data Data from questionnaire.
  */
 exports.printMessage = function printMessage(data, { green, yellow }) {
+  const packageManager = data.autoInstall ? data.autoInstall : 'npm (or if using yarn: yarn)'
+
   const message = `
 # ${green('Project initialization finished!')}
 # ========================
@@ -75,7 +77,7 @@ To get started:
   ${yellow(
     `${data.inPlace ? '' : `cd ${data.destDirName}\n  `}${installMsg(
       data
-    )}${lintMsg(data)}npm run dev`
+    )}${lintMsg(data)}${packageManager} run dev`
   )}
   
 Documentation can be found at https://vuejs-templates.github.io/webpack


### PR DESCRIPTION
Hi! This fixes #1366.

I guess there could be a generic way to handle every "npm" or "yarn" string in the setup process, but I realised that currently there are some ifs here and there.