### PR TITLE
Adds Manifest CommonChunk at dev build in order to have ES6 Single In…

### DIFF
--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -64,7 +64,14 @@ const devWebpackConfig = merge(baseWebpackConfig, {
         to: config.dev.assetsSubDirectory,
         ignore: ['.*']
       }
-    ])
+    ]),
+    // extract webpack runtime and module manifest to its own file in order to
+    // prevent vendor hash from being updated whenever app bundle is updated
+    // and allows ES6 Single Instance to work correctly with the dev bundle
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'manifest',
+      minChunks: Infinity
+    }),
   ]
 })
 


### PR DESCRIPTION
…stance working

At dev time `ES6 Module Single Instance Pattern` don't work because manifest is injected into each entrypoint. This disables shared modules (like a store) to share instance between multiple entrypoints rendering on the same page (not a SPA).
See:
https://github.com/vuejs/vue-cli/issues/1246

This fix by adding the manifest in a common chunk (already present at prod build).