### PR TITLE
 `vue init` command updated to `vue-init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a project template for [vue-cli](https://github.com/vuejs/vue-cli). **It
 
 ``` bash
 $ npm install -g vue-cli
-$ vue init webpack my-project
+$ vue-init webpack my-project
 $ cd my-project
 $ npm install
 $ npm run dev
@@ -24,7 +24,7 @@ $ npm run dev
 This will scaffold the project using the `master` branch. If you wish to use the latest version of the webpack template, do the following instead:
 
 ``` bash
-$ vue init webpack#develop my-project
+$ vue-init webpack#develop my-project
 ```
 
 :warning: **The develop branch is not considered stable and can contain bugs or not build at all, so use at your own risk.**
@@ -62,5 +62,5 @@ The development server will run on port 8080 by default. If that port is already
 You can fork this repo to create your own boilerplate, and use it with `vue-cli`:
 
 ``` bash
-vue init username/repo my-project
+vue-init username/repo my-project
 ```


### PR DESCRIPTION
`vue init` command when initializing project is incorrect and fails. The correct command is `vue-init` (or `sudo vue-init` if  root perm required).