### PR TITLE
Update parts of jest config to shorter simpler version

### DIFF
--- a/template/test/unit/jest.conf.js
+++ b/template/test/unit/jest.conf.js
@@ -11,15 +11,14 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/src/$1'
   },
   transform: {
-    '^.+\\.js$': '<rootDir>/node_modules/babel-jest',
-    '.*\\.(vue)$': '<rootDir>/node_modules/vue-jest'
+    '^.+\\.js$': 'babel-jest',
+    '.*\\.(vue)$': 'vue-jest'
   },{{#e2e}}
   testPathIgnorePatterns: [
     '<rootDir>/test/e2e'
   ],{{/e2e}}
-  snapshotSerializers: ['<rootDir>/node_modules/jest-serializer-vue'],
+  snapshotSerializers: ['jest-serializer-vue'],
   setupFiles: ['<rootDir>/test/unit/setup'],
-  mapCoverage: true,
   coverageDirectory: '<rootDir>/test/unit/coverage',
   collectCoverageFrom: [
     'src/**/*.{js,vue}',


### PR DESCRIPTION
Based on discussion from vue-jest where we updated the docs: https://github.com/vuejs/vue-jest/issues/94

Also removed mapCoverage cause of jest output and changes:
```
Deprecation Warning:

  Option "mapCoverage" has been removed, as it's no longer necessary.

  Please update your configuration.

  Configuration Documentation:
  https://facebook.github.io/jest/docs/configuration.html
```

Tested and works fine with changes.
Thanks!