### PR TITLE
feat: sourcemap entries to origin disk location

### DIFF
--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -19,6 +19,11 @@ const devWebpackConfig = merge(baseWebpackConfig, {
   },
   // cheap-module-eval-source-map is faster for development
   devtool: config.dev.devtool,
+  output: {
+    // Point sourcemap entries to original disk location (format as URL on Windows)
+    devtoolModuleFilenameTemplate: info =>
+      path.resolve(info.absoluteResourcePath).replace(/\\/g, '/')
+  },
 
   // these devServer options should be customized in /config/index.js
   devServer: {


### PR DESCRIPTION
## sourcemap entries to origin disk location
I debug in vs code, when I add breakpoint in file, the breakpoint may be unverified or not effect, and must open a readonly sourcemap file; when I debug in Chrome, sometimes, I must to refresh to update sourcemap   
I compare with `create-react-app`, and find some different
```js
  output: {
    // Point sourcemap entries to original disk location (format as URL on Windows)
    devtoolModuleFilenameTemplate: info =>
      path.resolve(info.absoluteResourcePath).replace(/\\/g, '/')
  },
```
I am so sorry I don't modify anything even comment.

thanks for your time