### PR TITLE
Upgrade jest

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -52,7 +52,7 @@
     "babel-jest": "^21.0.2",
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
-    "jest": "^22.0.4",
+    "jest": "^23.5.0",
     "jest-serializer-vue": "^0.3.0",
     "vue-jest": "^1.0.2",
     {{/if_eq}}


### PR DESCRIPTION
The following errors were fixed.
```
  ● Test suite failed to run

      SecurityError: localStorage is not available for opaque origins

            at Window.get localStorage [as localStorage]
            (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
                      at Array.forEach (<anonymous>)
```

* https://github.com/facebook/jest/blob/master/CHANGELOG.md#2350
    * https://github.com/facebook/jest/pull/6792