### PR TITLE
sloves #96: ignore node_modules/ watching ²

### DIFF
--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -42,6 +42,7 @@ const devWebpackConfig = merge(baseWebpackConfig, {
     quiet: true, // necessary for FriendlyErrorsPlugin
     watchOptions: {
       poll: config.dev.poll,
+      ignored: /node_modules/,
     }
   },
   plugins: [


### PR DESCRIPTION
See https://webpack.js.org/configuration/watch/#not-enough-watchers
This kind of solve the problem, even if I agree with @luaz : it would be better to just warn the user and cancel the watch task, but I have found nothing in the doc of webpack about how to cancel a build.

I would understand that you would not merge this: it forces users to re-start webpack after installing or updating a package, but it prevents from a silent error. 