### PR TITLE
changed NPM to npm

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -140,7 +140,7 @@ module.exports = {
         'Should we run `npm install` for you after the project has been created? (recommended)',
       choices: [
         {
-          name: 'Yes, use NPM',
+          name: 'Yes, use npm',
           value: 'npm',
           short: 'npm',
         },


### PR DESCRIPTION
This becomes somewhat older knowledge, but in old days `npm` had `faq` command, which said:

>  npm  should  never  be  capitalized  unless  it  is  being displayed in a location that is customarily all-caps (such as the title of man pages.)

I could not find this in the latest npm CLI, but it is still possible to find it [here](http://manpages.ubuntu.com/manpages/cosmic/man7/npm-faq.7.html). You can also see that both [wiki](https://en.wikipedia.org/wiki/Npm_(software)) and [npm website](https://www.npmjs.com/) refers to npm in all lower case. 

Likely, it's not super important, just something to consider merging.