### PR TITLE
Allow Bundling Using Different NODE_ENV

### DIFF
--- a/template/build/build.js
+++ b/template/build/build.js
@@ -1,7 +1,7 @@
 'use strict'
 require('./check-versions')()
 
-process.env.NODE_ENV = 'production'
+process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
 const ora = require('ora')
 const rm = require('rimraf')


### PR DESCRIPTION
When running 
```
npm run build
```
by default, it runs production build, taking production config only because in the build.js the NODE_ENV is hardcoded.
It should allowing different NODE_ENV.

Before
```
process.env.NODE_ENV =  'production'
```

After
```
process.env.NODE_ENV = process.env.NODE_ENV || 'production'
```

